### PR TITLE
Restore ability to test against different clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+KAFKA_BROKERS ?= "127.0.0.1:9092"
+KAFKA_TOPIC ?= "tester"
+
 .PHONY: build
 build:
 	cargo build --all --examples
@@ -6,7 +9,7 @@ build:
 .PHONY: check
 check:
 	cargo clippy -- --no-deps
-	KAFKA_BROKERS=127.0.0.1:9092 KAFKA_TOPIC=tester cargo test --tests -- --show-output --test-threads=1
+	KAFKA_BROKERS=$(KAFKA_BROKERS) KAFKA_TOPIC=$(KAFKA_TOPIC) cargo test --tests -- --show-output --test-threads=1
 
 
 .PHONY: bench


### PR DESCRIPTION
Are you sure you want these env vars in here at all? This breaks the ability to run unit tests only, when there's no broker.