### PR TITLE
Fix: Consumer cannot stream when caller only has a reference to a wrapper struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Samsa Changelog
 
+## [Unreleased]
+### Changed
+- [#39](https://github.com/CallistoLabsNYC/samsa/issues/39) Consumer cannot stream when caller only has a reference to a wrapper struct
+
 ## [0.1.2] - 2024-03-09
 ### Added
 - [#25](https://github.com/CallistoLabsNYC/samsa/issues/25) Offer a way to read from a Consumer without streaming

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -107,7 +107,7 @@ pub type PartitionOffsets = HashMap<TopicPartitionKey, i64>;
 ///     println!("{:?}", batch);
 /// }
 /// ```
-#[derive(Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Consumer {
     /// Keeps track of the brokers and the topic partition info for the cluster.
     pub(crate) cluster_metadata: ClusterMetadata,
@@ -423,4 +423,22 @@ pub async fn fetch(
         protocol::FetchResponse::try_from(broker_conn.receive_response().await?.freeze())?;
 
     Ok(response)
+}
+
+#[cfg(test)]
+mod test {
+    use super::Consumer;
+
+    struct ConsumerWrapper {
+        consumer: Consumer,
+    }
+
+    #[tokio::test]
+    async fn it_can_stream_via_ref_to_wrapper() {
+        let consumer = Consumer {
+            ..Default::default()
+        };
+        let wrapper = &ConsumerWrapper { consumer };
+        let _stream = wrapper.consumer.clone().into_stream();
+    }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -11,7 +11,7 @@ use crate::{
     protocol::{self, metadata::response::*},
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct ClusterMetadata {
     pub broker_connections: HashMap<i32, BrokerConnection>,
     pub brokers: Vec<Broker>,


### PR DESCRIPTION
Closes #39.