### PR TITLE
Decompose ConsumerGroup and ConsumerGroupBuilder modules to improve module encapsulation and readability

### DIFF
--- a/src/consumer_group.rs
+++ b/src/consumer_group.rs
@@ -10,32 +10,16 @@ use crate::{
     assignor::{assign, ROUND_ROBIN_PROTOCOL},
     consumer::{ConsumeMessage, FetchParams, TopicPartitions},
     consumer_builder::ConsumerBuilder,
-    error::{Error, KafkaCode, Result},
+    error::{KafkaCode, Result},
     network::BrokerConnection,
     protocol::{
         self,
         join_group::request::{Metadata, Protocol},
         Assignment,
     },
-    DEFAULT_CLIENT_ID, DEFAULT_CORRELATION_ID,
 };
 
 const DEFAULT_PROTOCOL_TYPE: &str = "consumer";
-const DEFAULT_RETENTION_TIME_MS: i64 = 100000;
-const DEFAULT_SESSION_TIMEOUT_MS: i32 = 10000;
-const DEFAUTL_REBALANCE_TIMEOUT_MS: i32 = 10000;
-
-pub struct ConsumerGroupBuilder {
-    pub bootstrap_addrs: Vec<String>,
-    pub correlation_id: i32,
-    pub client_id: String,
-    pub session_timeout_ms: i32,
-    pub rebalance_timeout_ms: i32,
-    pub group_id: String,
-    pub retention_time_ms: i64,
-    pub group_topic_partitions: TopicPartitions,
-    pub fetch_params: FetchParams,
-}
 
 pub struct ConsumerGroup {
     pub bootstrap_addrs: Vec<String>,
@@ -51,111 +35,6 @@ pub struct ConsumerGroup {
     pub retention_time_ms: i64,
     pub group_topic_partitions: TopicPartitions,
     pub fetch_params: FetchParams,
-}
-
-impl<'a> ConsumerGroupBuilder {
-    /// Start a consumer group builder. To complete, use the [`build`](Self::build) method.
-    pub async fn new(
-        bootstrap_addrs: Vec<String>,
-        group_id: String,
-        group_topic_partitions: TopicPartitions,
-    ) -> Result<Self> {
-        Ok(Self {
-            bootstrap_addrs,
-            correlation_id: DEFAULT_CORRELATION_ID,
-            client_id: DEFAULT_CLIENT_ID.to_owned(),
-            session_timeout_ms: DEFAULT_SESSION_TIMEOUT_MS,
-            rebalance_timeout_ms: DEFAUTL_REBALANCE_TIMEOUT_MS,
-            group_id,
-            retention_time_ms: DEFAULT_RETENTION_TIME_MS,
-            group_topic_partitions,
-            fetch_params: FetchParams::new(),
-        })
-    }
-
-    pub fn correlation_id(mut self, correlation_id: i32) -> Self {
-        self.fetch_params.correlation_id = correlation_id;
-        self
-    }
-
-    pub fn client_id(mut self, client_id: String) -> Self {
-        self.fetch_params.client_id = client_id;
-        self
-    }
-
-    pub fn retention_time_ms(mut self, retention_time_ms: i64) -> Self {
-        self.retention_time_ms = retention_time_ms;
-        self
-    }
-    pub fn session_timeout_ms(mut self, session_timeout_ms: i32) -> Self {
-        self.session_timeout_ms = session_timeout_ms;
-        self
-    }
-    pub fn rebalance_timeout_ms(mut self, rebalance_timeout_ms: i32) -> Self {
-        self.rebalance_timeout_ms = rebalance_timeout_ms;
-        self
-    }
-
-    /// The maximum time in milliseconds to wait for the response.
-    pub fn max_wait_ms(mut self, max_wait_ms: i32) -> Self {
-        self.fetch_params.max_wait_ms = max_wait_ms;
-        self
-    }
-
-    /// The minimum bytes to accumulate in the response.
-    pub fn min_bytes(mut self, min_bytes: i32) -> Self {
-        self.fetch_params.min_bytes = min_bytes;
-        self
-    }
-
-    /// The maximum bytes to fetch. See KIP-74 for cases where this limit may not be honored.
-    pub fn max_bytes(mut self, max_bytes: i32) -> Self {
-        self.fetch_params.max_bytes = max_bytes;
-        self
-    }
-
-    /// The maximum bytes to fetch from the partitions. See KIP-74 for cases where this limit may not be honored.
-    pub fn max_partition_bytes(mut self, max_partition_bytes: i32) -> Self {
-        self.fetch_params.max_partition_bytes = max_partition_bytes;
-        self
-    }
-
-    /// This setting controls the visibility of transactional records. Using READ_UNCOMMITTED (isolation_level = 0) makes all records visible. With READ_COMMITTED (isolation_level = 1), non-transactional and COMMITTED transactional records are visible. To be more concrete, READ_COMMITTED returns all data from offsets smaller than the current LSO (last stable offset), and enables the inclusion of the list of aborted transactions in the result, which allowss to discard ABORTED transactional records
-    pub fn isolation_level(mut self, isolation_level: i8) -> Self {
-        self.fetch_params.isolation_level = isolation_level;
-        self
-    }
-
-    pub async fn build(self) -> Result<ConsumerGroup> {
-        let conn = BrokerConnection::new(self.bootstrap_addrs.clone()).await?;
-        let coordinator =
-            find_coordinator(conn, self.correlation_id, &self.client_id, &self.group_id).await?;
-
-        if coordinator.error_code != KafkaCode::None {
-            return Err(Error::KafkaError(coordinator.error_code));
-        }
-
-        let host = std::str::from_utf8(coordinator.host.as_bytes()).unwrap();
-        let port = coordinator.port;
-        let coordinator_addr = format!("{}:{}", host, port);
-        let coordinator_conn = BrokerConnection::new(vec![coordinator_addr]).await?;
-
-        Ok(ConsumerGroup {
-            bootstrap_addrs: self.bootstrap_addrs,
-            coordinator_conn,
-            correlation_id: self.correlation_id,
-            client_id: self.client_id,
-            session_timeout_ms: self.session_timeout_ms,
-            rebalance_timeout_ms: self.rebalance_timeout_ms,
-            group_id: self.group_id,
-            retention_time_ms: self.retention_time_ms,
-            group_topic_partitions: self.group_topic_partitions,
-            fetch_params: self.fetch_params,
-            member_id: Bytes::from_static(b""),
-            generation_id: 0,
-            assignment: None,
-        })
-    }
 }
 
 impl ConsumerGroup {
@@ -354,26 +233,6 @@ impl ConsumerGroup {
             }
         }
     }
-}
-
-/// Locate the current coordinator of a group.
-///
-/// See this [protocol spec] for more information.
-///
-/// [protocol spec]: protocol::find_coordinator
-pub async fn find_coordinator(
-    conn: BrokerConnection,
-    correlation_id: i32,
-    client_id: &str,
-    group_id: &str,
-) -> Result<protocol::FindCoordinatorResponse> {
-    let find_coordinator_request =
-        protocol::FindCoordinatorRequest::new(correlation_id, client_id, group_id);
-    conn.send_request(&find_coordinator_request).await?;
-
-    let find_coordinator_response = conn.receive_response().await?;
-
-    protocol::FindCoordinatorResponse::try_from(find_coordinator_response.freeze())
 }
 
 /// Synchronize state for all members of a group (e.g. distribute partition assignments to consumers).

--- a/src/consumer_group_builder.rs
+++ b/src/consumer_group_builder.rs
@@ -1,0 +1,151 @@
+use bytes::Bytes;
+use nom::AsBytes;
+
+use crate::{
+    consumer::{FetchParams, TopicPartitions},
+    consumer_group::ConsumerGroup,
+    error::{Error, KafkaCode, Result},
+    network::BrokerConnection,
+    protocol, DEFAULT_CLIENT_ID, DEFAULT_CORRELATION_ID,
+};
+
+const DEFAULT_RETENTION_TIME_MS: i64 = 100000;
+const DEFAULT_SESSION_TIMEOUT_MS: i32 = 10000;
+const DEFAUTL_REBALANCE_TIMEOUT_MS: i32 = 10000;
+
+pub struct ConsumerGroupBuilder {
+    pub bootstrap_addrs: Vec<String>,
+    pub correlation_id: i32,
+    pub client_id: String,
+    pub session_timeout_ms: i32,
+    pub rebalance_timeout_ms: i32,
+    pub group_id: String,
+    pub retention_time_ms: i64,
+    pub group_topic_partitions: TopicPartitions,
+    pub fetch_params: FetchParams,
+}
+
+impl<'a> ConsumerGroupBuilder {
+    /// Start a consumer group builder. To complete, use the [`build`](Self::build) method.
+    pub async fn new(
+        bootstrap_addrs: Vec<String>,
+        group_id: String,
+        group_topic_partitions: TopicPartitions,
+    ) -> Result<Self> {
+        Ok(Self {
+            bootstrap_addrs,
+            correlation_id: DEFAULT_CORRELATION_ID,
+            client_id: DEFAULT_CLIENT_ID.to_owned(),
+            session_timeout_ms: DEFAULT_SESSION_TIMEOUT_MS,
+            rebalance_timeout_ms: DEFAUTL_REBALANCE_TIMEOUT_MS,
+            group_id,
+            retention_time_ms: DEFAULT_RETENTION_TIME_MS,
+            group_topic_partitions,
+            fetch_params: FetchParams::new(),
+        })
+    }
+
+    pub fn correlation_id(mut self, correlation_id: i32) -> Self {
+        self.fetch_params.correlation_id = correlation_id;
+        self
+    }
+
+    pub fn client_id(mut self, client_id: String) -> Self {
+        self.fetch_params.client_id = client_id;
+        self
+    }
+
+    pub fn retention_time_ms(mut self, retention_time_ms: i64) -> Self {
+        self.retention_time_ms = retention_time_ms;
+        self
+    }
+    pub fn session_timeout_ms(mut self, session_timeout_ms: i32) -> Self {
+        self.session_timeout_ms = session_timeout_ms;
+        self
+    }
+    pub fn rebalance_timeout_ms(mut self, rebalance_timeout_ms: i32) -> Self {
+        self.rebalance_timeout_ms = rebalance_timeout_ms;
+        self
+    }
+
+    /// The maximum time in milliseconds to wait for the response.
+    pub fn max_wait_ms(mut self, max_wait_ms: i32) -> Self {
+        self.fetch_params.max_wait_ms = max_wait_ms;
+        self
+    }
+
+    /// The minimum bytes to accumulate in the response.
+    pub fn min_bytes(mut self, min_bytes: i32) -> Self {
+        self.fetch_params.min_bytes = min_bytes;
+        self
+    }
+
+    /// The maximum bytes to fetch. See KIP-74 for cases where this limit may not be honored.
+    pub fn max_bytes(mut self, max_bytes: i32) -> Self {
+        self.fetch_params.max_bytes = max_bytes;
+        self
+    }
+
+    /// The maximum bytes to fetch from the partitions. See KIP-74 for cases where this limit may not be honored.
+    pub fn max_partition_bytes(mut self, max_partition_bytes: i32) -> Self {
+        self.fetch_params.max_partition_bytes = max_partition_bytes;
+        self
+    }
+
+    /// This setting controls the visibility of transactional records. Using READ_UNCOMMITTED (isolation_level = 0) makes all records visible. With READ_COMMITTED (isolation_level = 1), non-transactional and COMMITTED transactional records are visible. To be more concrete, READ_COMMITTED returns all data from offsets smaller than the current LSO (last stable offset), and enables the inclusion of the list of aborted transactions in the result, which allowss to discard ABORTED transactional records
+    pub fn isolation_level(mut self, isolation_level: i8) -> Self {
+        self.fetch_params.isolation_level = isolation_level;
+        self
+    }
+
+    pub async fn build(self) -> Result<ConsumerGroup> {
+        let conn = BrokerConnection::new(self.bootstrap_addrs.clone()).await?;
+        let coordinator =
+            find_coordinator(conn, self.correlation_id, &self.client_id, &self.group_id).await?;
+
+        if coordinator.error_code != KafkaCode::None {
+            return Err(Error::KafkaError(coordinator.error_code));
+        }
+
+        let host = std::str::from_utf8(coordinator.host.as_bytes()).unwrap();
+        let port = coordinator.port;
+        let coordinator_addr = format!("{}:{}", host, port);
+        let coordinator_conn = BrokerConnection::new(vec![coordinator_addr]).await?;
+
+        Ok(ConsumerGroup {
+            bootstrap_addrs: self.bootstrap_addrs,
+            coordinator_conn,
+            correlation_id: self.correlation_id,
+            client_id: self.client_id,
+            session_timeout_ms: self.session_timeout_ms,
+            rebalance_timeout_ms: self.rebalance_timeout_ms,
+            group_id: self.group_id,
+            retention_time_ms: self.retention_time_ms,
+            group_topic_partitions: self.group_topic_partitions,
+            fetch_params: self.fetch_params,
+            member_id: Bytes::from_static(b""),
+            generation_id: 0,
+            assignment: None,
+        })
+    }
+}
+
+/// Locate the current coordinator of a group.
+///
+/// See this [protocol spec] for more information.
+///
+/// [protocol spec]: protocol::find_coordinator
+pub async fn find_coordinator(
+    conn: BrokerConnection,
+    correlation_id: i32,
+    client_id: &str,
+    group_id: &str,
+) -> Result<protocol::FindCoordinatorResponse> {
+    let find_coordinator_request =
+        protocol::FindCoordinatorRequest::new(correlation_id, client_id, group_id);
+    conn.send_request(&find_coordinator_request).await?;
+
+    let find_coordinator_response = conn.receive_response().await?;
+
+    protocol::FindCoordinatorResponse::try_from(find_coordinator_response.freeze())
+}

--- a/src/consumer_group_builder.rs
+++ b/src/consumer_group_builder.rs
@@ -11,7 +11,7 @@ use crate::{
 
 const DEFAULT_RETENTION_TIME_MS: i64 = 100000;
 const DEFAULT_SESSION_TIMEOUT_MS: i32 = 10000;
-const DEFAUTL_REBALANCE_TIMEOUT_MS: i32 = 10000;
+const DEFAULT_REBALANCE_TIMEOUT_MS: i32 = 10000;
 
 pub struct ConsumerGroupBuilder {
     pub bootstrap_addrs: Vec<String>,
@@ -37,7 +37,7 @@ impl<'a> ConsumerGroupBuilder {
             correlation_id: DEFAULT_CORRELATION_ID,
             client_id: DEFAULT_CLIENT_ID.to_owned(),
             session_timeout_ms: DEFAULT_SESSION_TIMEOUT_MS,
-            rebalance_timeout_ms: DEFAUTL_REBALANCE_TIMEOUT_MS,
+            rebalance_timeout_ms: DEFAULT_REBALANCE_TIMEOUT_MS,
             group_id,
             retention_time_ms: DEFAULT_RETENTION_TIME_MS,
             group_topic_partitions,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,7 @@ pub mod prelude {
     //! [`list_offsets`] finds the offsets given a timestamp.
     //! #### Example
     //! ```rust
+    //! use samsa::prelude::list_offsets;
     //! let topic_partitions = HashMap::from([("my-topic", vec![0, 1, 2, 3])]);
     //! let offset_response = list_offsets(
     //!     conn,
@@ -277,6 +278,7 @@ pub mod prelude {
     //! [`fetch`] fetches a batch of messages.
     //! #### Example
     //! ```rust
+    //! use samsa::prelude::fetch;
     //! let fetch_response = fetch(
     //!     broker_conn,
     //!     correlation_id,
@@ -295,6 +297,7 @@ pub mod prelude {
     //! [`fetch_offset`] gets the offsets of a consumer group.
     //! #### Example
     //! ```rust
+    //! use samsa::prelude::fetch_offset;
     //! let offset_fetch_response = fetch_offset(
     //!     correlation_id,
     //!     client_id,
@@ -307,6 +310,7 @@ pub mod prelude {
     //! [`commit_offset`] commits a set of offsets for a group.
     //! #### Example
     //! ```rust
+    //! use samsa::prelude::commit_offset;
     //! let offset_commit_response = commit_offset(
     //!     correlation_id,
     //!     client_id,
@@ -338,6 +342,7 @@ pub mod prelude {
     //!
     //! ### Example
     //! ```rust
+    //! use tokio_stream::StreamExt;
     //! let bootstrap_addrs = vec!["127.0.0.1:9092".to_string()];
     //! let partitions = vec![0];
     //! let topic_name = "my-topic";
@@ -370,6 +375,7 @@ pub mod prelude {
     //! [`join_group`] Become a member of a group, creating it if there are no active members..
     //! #### Example
     //! ```rust
+    //! use samsa::prelude::join_group;
     //! let join_response = join_group(
     //!     correlation_id,
     //!     client_id,
@@ -385,6 +391,7 @@ pub mod prelude {
     //! [`sync_group`] Synchronize state for all members of a group.
     //! #### Example
     //! ```rust
+    //! use samsa::prelude::sync_group;
     //! let sync_response = sync_group(
     //!     correlation_id,
     //!     client_id,
@@ -399,6 +406,7 @@ pub mod prelude {
     //! [`heartbeat`] Keep a member alive in the group.
     //! #### Example
     //! ```rust
+    //! use samsa::prelude::heartbeat;
     //! let heartbeat_response = heartbeat(
     //!     correlation_id,
     //!     client_id,
@@ -412,6 +420,7 @@ pub mod prelude {
     //! [`leave_group`] Directly depart a group.
     //! #### Example
     //! ```rust
+    //! use samsa::prelude::leave_group;
     //! let leave_response = leave_group(
     //!     correlation_id, client_id, group_id, member_id
     //! ).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ mod assignor;
 mod consumer;
 mod consumer_builder;
 mod consumer_group;
+mod consumer_group_builder;
 mod encode;
 mod error;
 mod metadata;
@@ -129,7 +130,6 @@ mod producer_builder;
 mod protocol;
 mod utils;
 
-mod consumer_group_builder;
 #[cfg(feature = "redpanda")]
 mod redpanda;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ mod producer_builder;
 mod protocol;
 mod utils;
 
+mod consumer_group_builder;
 #[cfg(feature = "redpanda")]
 mod redpanda;
 
@@ -432,9 +433,9 @@ pub mod prelude {
     };
     pub use crate::consumer_builder::{fetch_offset, list_offsets, ConsumerBuilder};
     pub use crate::consumer_group::{
-        find_coordinator, heartbeat, join_group, leave_group, sync_group, ConsumerGroup,
-        ConsumerGroupBuilder,
+        heartbeat, join_group, leave_group, sync_group, ConsumerGroup,
     };
+    pub use crate::consumer_group_builder::{find_coordinator, ConsumerGroupBuilder};
     pub use crate::error::{Error, KafkaCode, Result};
     pub use crate::metadata::ClusterMetadata;
     pub use crate::network::BrokerConnection;


### PR DESCRIPTION
Also fix a few IntelliJ warnings about docs not showing required use statements.