### PR TITLE
Fix: Static Analysis and Build CI actions run with no purpose during tag release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   static_analysis:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v3
       - name: rustup
@@ -26,6 +27,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
     - uses: actions/checkout@v3
     - uses: adambirds/docker-compose-action@v1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Samsa Changelog
 
+## [Unreleased]
+### Fixed
+- [#56](https://github.com/CallistoLabsNYC/samsa/issues/56) Static Analysis and Build CI actions run with no purpose during tag release
+
 ## [0.1.4] - 2024-04-06
 ### Added
 - [#51](https://github.com/CallistoLabsNYC/samsa/issues/51) Add create and delete topic protocol support


### PR DESCRIPTION
Fixes #56.

Tested by setting a `0.1.0+1` tag, which was expected to fail at publishing another `0.1.0` release to crates.io where that release already exists.

![Screenshot 2024-04-06 at 7 42 05 AM](https://github.com/CallistoLabsNYC/samsa/assets/1109387/461ce9ca-5b30-4d49-a387-70c189ad8912)