### PR TITLE
Fix: ConsumerGroup cannot stream when caller only has a reference to a wrapper struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Samsa Changelog
 
 ## [Unreleased]
+### Changed
+- [#58](https://github.com/CallistoLabsNYC/samsa/issues/58) ConsumerGroup cannot stream when caller only has a reference to a wrapper struct
+
 ### Fixed
 - [#56](https://github.com/CallistoLabsNYC/samsa/issues/56) Static Analysis and Build CI actions run with no purpose during tag release
 

--- a/src/consumer_group.rs
+++ b/src/consumer_group.rs
@@ -21,6 +21,7 @@ use crate::{
 
 const DEFAULT_PROTOCOL_TYPE: &str = "consumer";
 
+#[derive(Clone, Debug)]
 pub struct ConsumerGroup {
     pub bootstrap_addrs: Vec<String>,
     pub coordinator_conn: BrokerConnection,


### PR DESCRIPTION
Closes #58.