### PR TITLE
Add topic partition assignment convenience types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Changed
 - [#58](https://github.com/CallistoLabsNYC/samsa/issues/58) ConsumerGroup cannot stream when caller only has a reference to a wrapper struct
+- [#34](https://github.com/CallistoLabsNYC/samsa/issues/34) Add documentation and comments for TopicAssignments & TopicPartition structs
 
 ### Fixed
 - [#56](https://github.com/CallistoLabsNYC/samsa/issues/56) Static Analysis and Build CI actions run with no purpose during tag release

--- a/README.md
+++ b/README.md
@@ -59,11 +59,14 @@ producer_client
 ```
 
 ### Consumer
+A `Consumer` is used to fetch messages from the broker. It is an asynchronous iterator that can be configured to auto-commit. To instantiate one, start with a `ConsumerBuilder`.
 ```rust
 let bootstrap_addrs = vec!["127.0.0.1:9092".to_string()];
 let partitions = vec![0];
 let topic_name = "my-topic";
-let assignment = std::collections::HashMap::from([(topic_name.to_string(), partitions)]);
+let assignment = samsa::prelude::TopicPartitionsBuilder::new()
+    .assign(topic_name, partitions)
+    .build();
 
 let consumer = samsa::prelude::ConsumerBuilder::new(
     bootstrap_addrs,
@@ -88,7 +91,9 @@ You can set up a consumer group with a group id and assignment. The offsets are 
 let bootstrap_addrs = vec!["127.0.0.1:9092".to_string()];
 let partitions = vec![0];
 let topic_name = "my-topic";
-let assignment = std::collections::HashMap::from([(topic_name.to_string(), partitions)]);
+let assignment = samsa::prelude::TopicPartitionsBuilder::new()
+    .assign(topic_name, partitions)
+    .build();
 let group_id = "The Data Boyz".to_string();
 
 let consumer_group_member = samsa::prelude::ConsumerGroupBuilder::new(
@@ -97,7 +102,7 @@ let consumer_group_member = samsa::prelude::ConsumerGroupBuilder::new(
     assignment,
 ).await?
 .build().await?;
- 
+
 let stream = consumer_group_member.into_stream();
 // have to pin streams before iterating
 tokio::pin!(stream);
@@ -110,5 +115,5 @@ while let Some(batch) = stream.next().await {
 
 
 ## Resources
-- https://kafka.apache.org/protocol.html
-- https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol
+- [Kafka Protocol Spec](https://kafka.apache.org/protocol.html)
+- [Confluence Docs](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol)

--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -27,7 +27,9 @@ async fn main() -> Result<(), ()> {
 
     let counter = ConsumerBuilder::new(
         bootstrap_addrs,
-        TopicPartitionsBuilder::new().assign(src_topic, vec![0, 1, 2, 3]).build(),
+        TopicPartitionsBuilder::new()
+            .assign(src_topic, vec![0, 1, 2, 3])
+            .build(),
     )
     .await
     .map_err(|err| tracing::error!("{:?}", err))?

--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use nom::AsBytes;
-use samsa::prelude::ConsumerBuilder;
+use samsa::prelude::{ConsumerBuilder, TopicPartitionsBuilder};
 use tokio_stream::StreamExt;
 
 #[tokio::main]
@@ -27,7 +27,7 @@ async fn main() -> Result<(), ()> {
 
     let counter = ConsumerBuilder::new(
         bootstrap_addrs,
-        HashMap::from([(src_topic, vec![0, 1, 2, 3])]),
+        TopicPartitionsBuilder::new().assign(src_topic, vec![0, 1, 2, 3]).build(),
     )
     .await
     .map_err(|err| tracing::error!("{:?}", err))?

--- a/examples/consumer_group.rs
+++ b/examples/consumer_group.rs
@@ -1,6 +1,8 @@
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
 use tokio_stream::StreamExt;
+use samsa::prelude::{ConsumerGroupBuilder, TopicPartitionsBuilder};
+
 
 #[tokio::main]
 async fn main() -> Result<(), ()> {
@@ -23,10 +25,10 @@ async fn main() -> Result<(), ()> {
 
     let src_topic = "shakespeare".to_string();
 
-    let stream = samsa::prelude::ConsumerGroupBuilder::new(
+    let stream = ConsumerGroupBuilder::new(
         bootstrap_addrs,
         "Squad".to_string(),
-        HashMap::from([(src_topic, vec![0, 1, 2, 3])]),
+        TopicPartitionsBuilder::new().assign(src_topic, vec![0, 1, 2, 3]).build(),
     )
     .await
     .map_err(|err| tracing::error!("{:?}", err))?

--- a/examples/consumer_group.rs
+++ b/examples/consumer_group.rs
@@ -1,8 +1,7 @@
 use std::time::Duration;
 
-use tokio_stream::StreamExt;
 use samsa::prelude::{ConsumerGroupBuilder, TopicPartitionsBuilder};
-
+use tokio_stream::StreamExt;
 
 #[tokio::main]
 async fn main() -> Result<(), ()> {
@@ -28,7 +27,9 @@ async fn main() -> Result<(), ()> {
     let stream = ConsumerGroupBuilder::new(
         bootstrap_addrs,
         "Squad".to_string(),
-        TopicPartitionsBuilder::new().assign(src_topic, vec![0, 1, 2, 3]).build(),
+        TopicPartitionsBuilder::new()
+            .assign(src_topic, vec![0, 1, 2, 3])
+            .build(),
     )
     .await
     .map_err(|err| tracing::error!("{:?}", err))?

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -103,6 +103,12 @@ impl TopicPartitionsBuilder {
     }
 }
 
+impl Default for TopicPartitionsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Used to represent topic partition offsets.
 pub type PartitionOffsets = HashMap<TopicPartitionKey, i64>;
 

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -64,8 +64,45 @@ impl FetchParams {
 }
 
 type TopicPartitionKey = (String, i32);
-/// Used to represent topic partition assignments.
+
+/// Used to represent topic-partition assignments.
+/// 
+/// Consumers need to be assigned to consume from topics and their partitions.
+/// The [TopicPartitionsBuilder] is an ease of use type to build these assignments
 pub type TopicPartitions = HashMap<String, Vec<i32>>;
+
+/// Build a topic-partition assignment for Consumers.
+/// 
+/// # Example
+/// ```rust
+/// let topic_partitions = TopicPartitionsBuilder::new()
+///     .assign("topic1", vec![0,1,2])
+///     .assign("topic1", vec![3,4,5])
+///     .build();
+/// ```
+pub struct TopicPartitionsBuilder {
+    data: TopicPartitions
+}
+
+impl TopicPartitionsBuilder {
+    pub fn new() -> Self {
+        Self {
+            data: HashMap::new()
+        }
+    }
+
+    /// Add assignment for a topic and its partitions.
+    pub fn assign(mut self, topic: String, partitions: Vec<i32>) -> Self {
+        self.data.insert(topic, partitions);
+
+        self
+    } 
+
+    pub fn build(self) -> TopicPartitions {
+        self.data
+    }
+}
+
 /// Used to represent topic partition offsets.
 pub type PartitionOffsets = HashMap<TopicPartitionKey, i64>;
 

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -66,13 +66,13 @@ impl FetchParams {
 type TopicPartitionKey = (String, i32);
 
 /// Used to represent topic-partition assignments.
-/// 
+///
 /// Consumers need to be assigned to consume from topics and their partitions.
 /// The [TopicPartitionsBuilder] is an ease of use type to build these assignments
 pub type TopicPartitions = HashMap<String, Vec<i32>>;
 
 /// Build a topic-partition assignment for Consumers.
-/// 
+///
 /// # Example
 /// ```rust
 /// let topic_partitions = TopicPartitionsBuilder::new()
@@ -81,13 +81,13 @@ pub type TopicPartitions = HashMap<String, Vec<i32>>;
 ///     .build();
 /// ```
 pub struct TopicPartitionsBuilder {
-    data: TopicPartitions
+    data: TopicPartitions,
 }
 
 impl TopicPartitionsBuilder {
     pub fn new() -> Self {
         Self {
-            data: HashMap::new()
+            data: HashMap::new(),
         }
     }
 
@@ -96,7 +96,7 @@ impl TopicPartitionsBuilder {
         self.data.insert(topic, partitions);
 
         self
-    } 
+    }
 
     pub fn build(self) -> TopicPartitions {
         self.data

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -126,7 +126,9 @@ pub type PartitionOffsets = HashMap<TopicPartitionKey, i64>;
 /// let bootstrap_addrs = vec!["127.0.0.1:9092".to_string()];
 /// let partitions = vec![0];
 /// let topic_name = "my-topic";
-/// let assignment = std::collections::HashMap::from([(topic_name.to_string(), partitions)]);
+/// let assignment = samsa::prelude::TopicPartitionsBuilder::new()
+///     .assign(topic_name, partitions)
+///     .build();
 ///
 /// let consumer = samsa::prelude::ConsumerBuilder::new(
 ///     bootstrap_addrs,

--- a/src/consumer_builder.rs
+++ b/src/consumer_builder.rs
@@ -17,7 +17,9 @@ use tracing::instrument;
 /// let bootstrap_addrs = vec!["127.0.0.1:9092".to_string()];
 /// let partitions = vec![0];
 /// let topic_name = "my-topic";
-/// let assignment = std::collections::HashMap::from([(topic_name.to_string(), partitions)]);
+/// let assignment = samsa::prelude::TopicPartitionsBuilder::new()
+///     .assign(topic_name, partitions)
+///     .build();
 ///
 /// let consumer = samsa::prelude::ConsumerBuilder::new(
 ///     bootstrap_addrs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,9 @@
 //! let bootstrap_addrs = vec!["127.0.0.1:9092".to_string()];
 //! let partitions = vec![0];
 //! let topic_name = "my-topic";
-//! let assignment = std::collections::HashMap::from([(topic_name.to_string(), partitions)]);
+//! let assignment = samsa::prelude::TopicPartitionsBuilder::new()
+//!     .assign(topic_name, partitions)
+//!     .build();
 //!
 //! let consumer = samsa::prelude::ConsumerBuilder::new(
 //!     bootstrap_addrs,
@@ -90,7 +92,9 @@
 //! let bootstrap_addrs = vec!["127.0.0.1:9092".to_string()];
 //! let partitions = vec![0];
 //! let topic_name = "my-topic";
-//! let assignment = std::collections::HashMap::from([(topic_name.to_string(), partitions)]);
+//! let assignment = samsa::prelude::TopicPartitionsBuilder::new()
+//!     .assign(topic_name, partitions)
+//!     .build();
 //! let group_id = "The Data Boyz".to_string();
 //!
 //! let consumer_group_member = samsa::prelude::ConsumerGroupBuilder::new(
@@ -238,7 +242,9 @@ pub mod prelude {
     //! let bootstrap_addrs = vec!["127.0.0.1:9092".to_string()];
     //! let partitions = vec![0];
     //! let topic_name = "my-topic";
-    //! let assignment = std::collections::HashMap::from([(topic_name.to_string(), partitions)]);
+    //! let assignment = samsa::prelude::TopicPartitionsBuilder::new()
+    //!     .assign(topic_name, partitions)
+    //!     .build();
     //!
     //! let consumer = samsa::prelude::ConsumerBuilder::new(
     //!     bootstrap_addrs,
@@ -268,7 +274,11 @@ pub mod prelude {
     //! ```rust
     //! use std::collections::HashMap;
     //! use samsa::prelude::list_offsets;
-    //! let topic_partitions = HashMap::from([("my-topic", vec![0, 1, 2, 3])]);
+    //! let partitions = vec![0];
+    //! let topic_name = "my-topic";
+    //! let topic_partitions = samsa::prelude::TopicPartitionsBuilder::new()
+    //!     .assign(topic_name, partitions)
+    //!     .build();
     //! let offset_response = list_offsets(
     //!     conn,
     //!     correlation_id,
@@ -350,7 +360,9 @@ pub mod prelude {
     //! let bootstrap_addrs = vec!["127.0.0.1:9092".to_string()];
     //! let partitions = vec![0];
     //! let topic_name = "my-topic";
-    //! let assignment = std::collections::HashMap::from([(topic_name.to_string(), partitions)]);
+    //! let assignment = samsa::prelude::TopicPartitionsBuilder::new()
+    //!     .assign(topic_name, partitions)
+    //!     .build();
     //! let group_id = "The Data Boyz".to_string();
     //!
     //! let consumer_group_member = samsa::prelude::ConsumerGroupBuilder::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,7 +445,8 @@ pub mod prelude {
     pub use crate::admin::{create_topics, delete_topics};
     pub use crate::assignor::ROUND_ROBIN_PROTOCOL;
     pub use crate::consumer::{
-        commit_offset, fetch, ConsumeMessage, Consumer, PartitionOffsets, TopicPartitions, TopicPartitionsBuilder
+        commit_offset, fetch, ConsumeMessage, Consumer, PartitionOffsets, TopicPartitions,
+        TopicPartitionsBuilder,
     };
     pub use crate::consumer_builder::{fetch_offset, list_offsets, ConsumerBuilder};
     pub use crate::consumer_group::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
 //!         partition_id,
 //!         key: Some(bytes::Bytes::from_static(b"Tester")),
 //!         value: Some(bytes::Bytes::from_static(b"Value")),
+//!         headers: vec![String::from("Key"), bytes::Bytes::from("Value")]
 //!     };
 //!
 //! let producer_client = samsa::prelude::ProducerBuilder::new(bootstrap_addrs, vec![topic_name.to_string()])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,7 +433,7 @@ pub mod prelude {
     pub use crate::admin::{create_topics, delete_topics};
     pub use crate::assignor::ROUND_ROBIN_PROTOCOL;
     pub use crate::consumer::{
-        commit_offset, fetch, ConsumeMessage, Consumer, PartitionOffsets, TopicPartitions,
+        commit_offset, fetch, ConsumeMessage, Consumer, PartitionOffsets, TopicPartitions, TopicPartitionsBuilder
     };
     pub use crate::consumer_builder::{fetch_offset, list_offsets, ConsumerBuilder};
     pub use crate::consumer_group::{


### PR DESCRIPTION
Could never remember the hard coded `HashMap::from([(key, value),(key, value)])` pattern, so I made a builder type and documented it.

# Issues
#34