### PR TITLE
Hgk/add openssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 /target
+/etc/redpanda/certs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "argh"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af5ba06967ff7214ce4c7419c7d185be7ecd6cc4965a8f6e1d8ce0398aad219"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56df0aeedf6b7a2fc67d06db35b09684c3e8da0c95f8f27685cb17e08413d87a"
+dependencies = [
+ "argh_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5693f39141bda5760ecc4111ab08da40565d1771038c4a0250f03457ec707531"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +125,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5509d663b2c00ee421bda8d6a24d6c42e15970957de1701b8df9f6fbe5707df1"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5d317212c2a78d86ba6622e969413c38847b62f48111f8b763af3dac2f9840"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +171,35 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.4.2",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
+]
 
 [[package]]
 name = "bitflags"
@@ -170,12 +257,36 @@ name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+dependencies = [
+ "jobserver",
+ "libc",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -186,6 +297,15 @@ dependencies = [
  "bitflags 1.3.2",
  "textwrap",
  "unicode-width",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -302,6 +422,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +493,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -475,6 +607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "h2"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +657,15 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "http"
@@ -633,6 +780,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,10 +804,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libloading"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.4",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -712,6 +884,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "native-tls"
@@ -950,6 +1128,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,7 +1263,7 @@ version = "0.11.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1093,7 +1281,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1110,10 +1298,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -1129,12 +1338,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4d6d8ad9f2492485e13453acbb291dd08f64441b6609c491f1c2cd2c6b4fe1"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.0",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1156,6 +1408,7 @@ dependencies = [
 name = "samsa"
 version = "0.1.4"
 dependencies = [
+ "argh",
  "async-stream",
  "bytes",
  "crc",
@@ -1167,13 +1420,17 @@ dependencies = [
  "num-traits",
  "random_word",
  "reqwest",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "serde",
  "serde_derive",
  "serde_json",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1277,6 +1534,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1572,18 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -1445,6 +1720,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,6 +1861,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +1994,27 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -1896,3 +2209,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["kafka", "redpanda", "confluent"]
 categories = ["api-bindings"]
 
 [dependencies]
+argh = "0.1.12"
 async-stream = "0.3.5"
 bytes = { version = "1.5.0" }
 crc = "3.0.1"
@@ -20,13 +21,17 @@ nombytes = "0.1.1"
 num-derive = "0.4.2"
 num-traits = "0.2.18"
 reqwest = { version = "0.11", features=['json'], optional = true }
+rustls-pemfile = "2.1.2"
+rustls-pki-types = "1.4.1"
 serde = { version = "1.0.193", optional = true }
 serde_derive = { version = "1.0.193", optional = true }
 serde_json = "1.0.108"
 tokio = { version = "1.36.0", features = ['full'] }
+tokio-rustls = "0.26.0"
 tokio-stream = "0.1.14"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
+webpki-roots = "0.26.1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,5 +46,6 @@ name = "encoder"
 harness = false
 
 [features]
+tls = []
 integration_tests = []
 redpanda = ["reqwest", "serde", "serde_derive"]

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -1,0 +1,78 @@
+use std::fs::File;
+use std::io;
+use std::io::BufReader;
+use std::net::ToSocketAddrs;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use argh::FromArgs;
+use samsa::prelude::encode::ToByte;
+use tokio::io::{copy, split, stdin as tokio_stdin, stdout as tokio_stdout, AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio_rustls::{rustls, TlsConnector};
+
+/// Tokio Rustls client example
+#[derive(FromArgs)]
+struct Options {
+    /// host
+    #[argh(positional)]
+    host: String,
+
+    /// port
+    #[argh(option, short = 'p', default = "443")]
+    port: u16,
+
+    /// domain
+    #[argh(option, short = 'd')]
+    domain: Option<String>,
+
+    /// cafile
+    #[argh(option, short = 'c')]
+    cafile: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    let options: Options = argh::from_env();
+
+    let addr = (options.host.as_str(), options.port)
+        .to_socket_addrs().unwrap()
+        .next()
+        .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound)).unwrap();
+    let domain = options.domain.unwrap_or(options.host);
+    let topics = vec!["tester"];
+
+    let mut root_cert_store = rustls::RootCertStore::empty();
+    if let Some(cafile) = &options.cafile {
+        let mut pem = BufReader::new(File::open(cafile).unwrap());
+        for cert in rustls_pemfile::certs(&mut pem) {
+            println!("adding!");
+            root_cert_store.add(cert.unwrap()).unwrap();
+        }
+    } else {
+        root_cert_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    }
+
+    let config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_cert_store)
+        .with_no_client_auth(); // i guess this was previously the default.unwrap()
+    let connector = TlsConnector::from(Arc::new(config));
+
+    let stream = TcpStream::connect(&addr).await.unwrap();
+
+    let (mut stdin, mut stdout) = (tokio_stdin(), tokio_stdout());
+
+    let domain = rustls_pki_types::ServerName::try_from(domain.as_str())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dnsname")).unwrap()
+        .to_owned();
+
+    let mut stream = connector.connect(domain, stream).await.unwrap();
+    
+    let req = samsa::prelude::protocol::MetadataRequest::new(1, "rust", &topics);
+    let mut buf = vec![];
+    req.encode(&mut buf).unwrap();
+    stream.write_all(&buf).await.unwrap();
+
+    // let size = stream.read_buf(buf)
+    Ok(())
+}

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -8,9 +8,7 @@ use std::io::BufReader;
 use std::net::ToSocketAddrs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::io::{
-   AsyncWriteExt,
-};
+use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 use tokio_rustls::{rustls, TlsConnector};
 
@@ -95,11 +93,16 @@ async fn main() -> io::Result<()> {
     let mut stream = connector.connect(domain, stream).await.unwrap();
 
     let mut req = samsa::prelude::protocol::ProduceRequest::new(0, 1000, 1, "rust");
-    req.add("test-1-user-signedup", 0, Some(bytes::Bytes::from("new")), Some(bytes::Bytes::from("old")), vec![]);
+    req.add(
+        "test-1-user-signedup",
+        0,
+        Some(bytes::Bytes::from("new")),
+        Some(bytes::Bytes::from("old")),
+        vec![],
+    );
     let mut buf = vec![];
     req.encode(&mut buf).unwrap();
     stream.write_all(&buf).await.unwrap();
-    
 
     // let size = stream.read_buf(buf)
     Ok(())

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -1,16 +1,18 @@
+use argh::FromArgs;
+use rustls_pemfile::{certs, pkcs8_private_keys};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer};
+use samsa::prelude::encode::ToByte;
 use std::fs::File;
 use std::io;
 use std::io::BufReader;
 use std::net::ToSocketAddrs;
-use std::sync::Arc;
 use std::path::{Path, PathBuf};
-use argh::FromArgs;
-use samsa::prelude::encode::ToByte;
-use tokio::io::{copy, split, stdin as tokio_stdin, stdout as tokio_stdout, AsyncReadExt, AsyncWriteExt};
+use std::sync::Arc;
+use tokio::io::{
+   AsyncWriteExt,
+};
 use tokio::net::TcpStream;
 use tokio_rustls::{rustls, TlsConnector};
-use rustls_pki_types::{CertificateDer, PrivateKeyDer};
-use rustls_pemfile::{certs, pkcs8_private_keys};
 
 /// Tokio Rustls client example
 #[derive(FromArgs)]
@@ -56,11 +58,12 @@ async fn main() -> io::Result<()> {
     let options: Options = argh::from_env();
 
     let addr = (options.host.as_str(), options.port)
-        .to_socket_addrs().unwrap()
+        .to_socket_addrs()
+        .unwrap()
         .next()
-        .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound)).unwrap();
+        .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))
+        .unwrap();
     let domain = options.domain.unwrap_or(options.host);
-    let topics = vec!["tester"];
 
     let certs = load_certs(&options.cert)?;
     let key = load_keys(&options.key)?;
@@ -78,24 +81,25 @@ async fn main() -> io::Result<()> {
 
     let config = rustls::ClientConfig::builder()
         .with_root_certificates(root_cert_store)
-        .with_client_auth_cert(certs, key).unwrap()
-        ;
+        .with_client_auth_cert(certs, key)
+        .unwrap();
     let connector = TlsConnector::from(Arc::new(config));
 
     let stream = TcpStream::connect(&addr).await.unwrap();
 
-    let (mut stdin, mut stdout) = (tokio_stdin(), tokio_stdout());
-
     let domain = rustls_pki_types::ServerName::try_from(domain.as_str())
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dnsname")).unwrap()
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dnsname"))
+        .unwrap()
         .to_owned();
 
     let mut stream = connector.connect(domain, stream).await.unwrap();
-    
-    let req = samsa::prelude::protocol::MetadataRequest::new(1, "rust", &topics);
+
+    let mut req = samsa::prelude::protocol::ProduceRequest::new(0, 1000, 1, "rust");
+    req.add("test-1-user-signedup", 0, Some(bytes::Bytes::from("new")), Some(bytes::Bytes::from("old")), vec![]);
     let mut buf = vec![];
     req.encode(&mut buf).unwrap();
     stream.write_all(&buf).await.unwrap();
+    
 
     // let size = stream.read_buf(buf)
     Ok(())

--- a/examples/tls2.rs
+++ b/examples/tls2.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), ()> {
             key: "./etc/redpanda/certs/client.key".into(),
             cert: "./etc/redpanda/certs/client.crt".into(),
             host: "piggy.callistolabs.cloud".to_owned(),
-            port: 9092
+            port: 9092,
         }],
         cafile: Some("./etc/redpanda/certs/root.crt".into()),
     };

--- a/examples/tls2.rs
+++ b/examples/tls2.rs
@@ -1,0 +1,49 @@
+use samsa::prelude::{protocol, ConnectionOptions, TlsBrokerOptions, TlsConnection};
+
+#[tokio::main]
+async fn main() -> Result<(), ()> {
+    tracing_subscriber::fmt()
+        // filter spans/events with level TRACE or higher.
+        .with_max_level(tracing::Level::TRACE)
+        .compact()
+        // Display source code file paths
+        .with_file(true)
+        // Display source code line numbers
+        .with_line_number(true)
+        // Display the thread ID an event was recorded on
+        .with_thread_ids(true)
+        // Don't display the event's target (module path)
+        .with_target(false)
+        // Build the subscriber
+        .init();
+    let options = ConnectionOptions {
+        broker_options: vec![TlsBrokerOptions {
+            key: "./etc/redpanda/certs/client.key".into(),
+            cert: "./etc/redpanda/certs/client.crt".into(),
+            host: "piggy.callistolabs.cloud".to_owned(),
+            port: 9092
+        }],
+        cafile: Some("./etc/redpanda/certs/root.crt".into()),
+    };
+
+    let conn = TlsConnection::new(options).await.unwrap();
+
+    let metta = metadata(conn).await;
+
+    println!("{:?}", metta);
+
+    Ok(())
+}
+
+pub async fn metadata(mut conn: TlsConnection) -> protocol::MetadataResponse {
+    let topics = vec![
+        "microcks-services-updates".to_string(),
+        "test-1-user-signedup".to_string(),
+    ];
+    let find_coordinator_request = protocol::MetadataRequest::new(1, "client_id", &topics);
+    conn.send_request(&find_coordinator_request).await.unwrap();
+
+    let find_coordinator_response = conn.receive_response().await.unwrap();
+
+    protocol::MetadataResponse::try_from(find_coordinator_response.freeze()).unwrap()
+}

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -6,8 +6,8 @@ use std::collections::HashMap;
 /// See this [protocol spec] for more information.
 ///
 /// [protocol spec]: protocol::create_topics
-pub async fn create_topics(
-    conn: BrokerConnection,
+pub async fn create_topics<T: BrokerConnection>(
+    mut conn: T,
     correlation_id: i32,
     client_id: &str,
     topics_with_partition_count: HashMap<&str, i32>,
@@ -31,8 +31,8 @@ pub async fn create_topics(
 /// See this [protocol spec] for more information.
 ///
 /// [protocol spec]: protocol::delete_topics
-pub async fn delete_topics(
-    conn: BrokerConnection,
+pub async fn delete_topics<T: BrokerConnection>(
+    mut conn: T,
     correlation_id: i32,
     client_id: &str,
     topics: Vec<&str>,

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -1,6 +1,6 @@
 //! Client that consumes records from a cluster.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Debug};
 
 use async_stream::try_stream;
 use bytes::Bytes;
@@ -339,11 +339,11 @@ pub fn into_flat_stream(
 /// [protocol spec]: protocol::commit_offset
 #[instrument(level = "debug")]
 #[allow(clippy::too_many_arguments)]
-pub async fn commit_offset(
+pub async fn commit_offset<T: BrokerConnection + Debug>(
     correlation_id: i32,
     client_id: &str,
     group_id: &str,
-    coordinator_conn: network::BrokerConnection,
+    coordinator_conn: T,
     generation_id: i32,
     member_id: Bytes,
     offsets: PartitionOffsets,
@@ -394,11 +394,11 @@ pub async fn commit_offset(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn commit_offset_wrapper(
+async fn commit_offset_wrapper<T: BrokerConnection + Debug>(
     correlation_id: i32,
     client_id: &str,
     group_id: &str,
-    coordinator_conn: network::BrokerConnection,
+    coordinator_conn: T,
     generation_id: i32,
     member_id: Bytes,
     offsets: PartitionOffsets,
@@ -425,8 +425,8 @@ async fn commit_offset_wrapper(
 /// [protocol spec]: protocol::fetch
 #[instrument(level = "debug")]
 #[allow(clippy::too_many_arguments)]
-pub async fn fetch(
-    broker_conn: BrokerConnection,
+pub async fn fetch<T: BrokerConnection + Debug>(
+    broker_conn: T,
     correlation_id: i32,
     client_id: &str,
     max_wait_ms: i32,

--- a/src/consumer_builder.rs
+++ b/src/consumer_builder.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use nom::AsBytes;
 use std::collections::HashMap;
+use std::fmt::Debug;
 use tracing::instrument;
 
 /// Configure a [`Consumer`].
@@ -258,11 +259,11 @@ impl<'a> ConsumerBuilder {
 
 /// Fetch a set of offsets for a consumer group.
 #[instrument(level = "debug")]
-pub async fn fetch_offset(
+pub async fn fetch_offset<T: BrokerConnection + Debug>(
     correlation_id: i32,
     client_id: &str,
     group_id: &str,
-    coordinator_conn: BrokerConnection,
+    mut coordinator_conn: T,
     topic_partitions: &TopicPartitions,
 ) -> Result<protocol::OffsetFetchResponse> {
     tracing::debug!(
@@ -288,8 +289,8 @@ pub async fn fetch_offset(
 ///
 /// See this [protocol spec](crate::prelude::protocol::list_offsets) for more information.
 #[instrument(level = "debug")]
-pub async fn list_offsets(
-    broker_conn: &BrokerConnection,
+pub async fn list_offsets<T: BrokerConnection + Debug>(
+    mut broker_conn: T,
     correlation_id: i32,
     client_id: &str,
     topic_partitions: &TopicPartitions,

--- a/src/consumer_builder.rs
+++ b/src/consumer_builder.rs
@@ -54,7 +54,7 @@ pub struct ConsumerBuilder<T: BrokerConnection> {
 impl<'a, T: BrokerConnection + Debug + Copy> ConsumerBuilder<T> {
     /// Start a consumer builder. To complete, use the [`build`](Self::build) method.
     pub async fn new(
-        connection_params: ConnectionParams,
+        connection_params: ConnectionParams<T>,
         assigned_topic_partitions: TopicPartitions,
     ) -> Result<Self> {
         let topics = assigned_topic_partitions

--- a/src/consumer_builder.rs
+++ b/src/consumer_builder.rs
@@ -54,7 +54,7 @@ pub struct ConsumerBuilder<T: BrokerConnection> {
 impl<'a, T: BrokerConnection + Debug + Copy> ConsumerBuilder<T> {
     /// Start a consumer builder. To complete, use the [`build`](Self::build) method.
     pub async fn new(
-        connection_params: ConnectionParams<T>,
+        connection_params: ConnectionParams,
         assigned_topic_partitions: TopicPartitions,
     ) -> Result<Self> {
         let topics = assigned_topic_partitions

--- a/src/consumer_group.rs
+++ b/src/consumer_group.rs
@@ -250,8 +250,8 @@ impl ConsumerGroup {
 /// See this [protocol spec] for more information.
 ///
 /// [protocol spec]: protocol::sync_group
-pub async fn sync_group<'a>(
-    conn: BrokerConnection,
+pub async fn sync_group<'a, T: BrokerConnection>(
+    conn: T,
     correlation_id: i32,
     client_id: &str,
     group_id: &str,
@@ -280,8 +280,8 @@ pub async fn sync_group<'a>(
 ///
 /// [protocol spec]: protocol::join_group
 #[allow(clippy::too_many_arguments)]
-pub async fn join_group<'a>(
-    conn: BrokerConnection,
+pub async fn join_group<'a, T: BrokerConnection>(
+    conn: T,
     correlation_id: i32,
     client_id: &str,
     group_id: &str,
@@ -312,8 +312,8 @@ pub async fn join_group<'a>(
 /// See this [protocol spec] for more information.
 ///
 /// [protocol spec]: protocol::heartbeat
-pub async fn heartbeat(
-    conn: BrokerConnection,
+pub async fn heartbeat<T: BrokerConnection>(
+    conn: T,
     correlation_id: i32,
     client_id: &str,
     group_id: &str,
@@ -339,8 +339,8 @@ pub async fn heartbeat(
 /// See this [protocol spec] for more information.
 ///
 /// [protocol spec]: protocol::leave_group
-pub async fn leave_group(
-    conn: BrokerConnection,
+pub async fn leave_group<T: BrokerConnection>(
+    conn: T,
     correlation_id: i32,
     client_id: &str,
     group_id: &str,

--- a/src/consumer_group.rs
+++ b/src/consumer_group.rs
@@ -23,7 +23,7 @@ const DEFAULT_PROTOCOL_TYPE: &str = "consumer";
 
 #[derive(Clone, Debug)]
 pub struct ConsumerGroup<T: BrokerConnection> {
-    pub connection_params: ConnectionParams<T>,
+    pub connection_params: ConnectionParams,
     pub coordinator_conn: T,
     pub correlation_id: i32,
     pub client_id: String,
@@ -191,7 +191,7 @@ impl<T: BrokerConnection + Debug + Copy> ConsumerGroup<T> {
                             acc
                         });
 
-                let consumer = ConsumerBuilder::new(self.connection_params, assigned_topic_partitions)
+                let consumer = ConsumerBuilder::new(self.connection_params.clone(), assigned_topic_partitions)
                     .await?
                     .seek_to_group(self.coordinator_conn, &self.group_id)
                     .await?

--- a/src/consumer_group.rs
+++ b/src/consumer_group.rs
@@ -1,6 +1,6 @@
 //! Consumer which cooperates with others to consume data.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Debug};
 
 use bytes::Bytes;
 use nom::AsBytes;
@@ -11,7 +11,7 @@ use crate::{
     consumer::{ConsumeMessage, FetchParams, TopicPartitions},
     consumer_builder::ConsumerBuilder,
     error::{Error, KafkaCode, Result},
-    network::BrokerConnection,
+    network::{BrokerConnection, ConnectionParams},
     protocol::{
         self,
         join_group::request::{Metadata, Protocol},
@@ -22,9 +22,9 @@ use crate::{
 const DEFAULT_PROTOCOL_TYPE: &str = "consumer";
 
 #[derive(Clone, Debug)]
-pub struct ConsumerGroup {
-    pub bootstrap_addrs: Vec<String>,
-    pub coordinator_conn: BrokerConnection,
+pub struct ConsumerGroup<T: BrokerConnection> {
+    pub connection_params: ConnectionParams,
+    pub coordinator_conn: T,
     pub correlation_id: i32,
     pub client_id: String,
     pub session_timeout_ms: i32,
@@ -38,7 +38,7 @@ pub struct ConsumerGroup {
     pub fetch_params: FetchParams,
 }
 
-impl ConsumerGroup {
+impl<T: BrokerConnection + Debug + Copy> ConsumerGroup<T> {
     pub fn into_stream(mut self) -> impl Stream<Item = Result<Vec<ConsumeMessage>>> {
         async_stream::stream! {
             loop {
@@ -63,7 +63,7 @@ impl ConsumerGroup {
                     .collect();
 
                 let join = join_group(
-                    self.coordinator_conn.clone(),
+                    self.coordinator_conn,
                     self.correlation_id,
                     &self.client_id,
                     &self.group_id,
@@ -138,7 +138,7 @@ impl ConsumerGroup {
                     assignments
                 );
                 let sync = sync_group(
-                    self.coordinator_conn.clone(),
+                    self.coordinator_conn,
                     self.correlation_id,
                     &self.client_id,
                     &self.group_id,
@@ -191,13 +191,13 @@ impl ConsumerGroup {
                             acc
                         });
 
-                let consumer = ConsumerBuilder::new(self.bootstrap_addrs.clone(), assigned_topic_partitions)
+                let consumer = ConsumerBuilder::new(self.connection_params, assigned_topic_partitions)
                     .await?
-                    .seek_to_group(self.coordinator_conn.clone(), &self.group_id)
+                    .seek_to_group(self.coordinator_conn, &self.group_id)
                     .await?
                     .build()
                     .into_autocommit_stream(
-                        self.coordinator_conn.clone(),
+                        self.coordinator_conn,
                         &self.group_id,
                         self.generation_id,
                         self.member_id.clone(),
@@ -251,7 +251,7 @@ impl ConsumerGroup {
 ///
 /// [protocol spec]: protocol::sync_group
 pub async fn sync_group<'a, T: BrokerConnection>(
-    conn: T,
+    mut conn: T,
     correlation_id: i32,
     client_id: &str,
     group_id: &str,
@@ -281,7 +281,7 @@ pub async fn sync_group<'a, T: BrokerConnection>(
 /// [protocol spec]: protocol::join_group
 #[allow(clippy::too_many_arguments)]
 pub async fn join_group<'a, T: BrokerConnection>(
-    conn: T,
+    mut conn: T,
     correlation_id: i32,
     client_id: &str,
     group_id: &str,
@@ -313,7 +313,7 @@ pub async fn join_group<'a, T: BrokerConnection>(
 ///
 /// [protocol spec]: protocol::heartbeat
 pub async fn heartbeat<T: BrokerConnection>(
-    conn: T,
+    mut conn: T,
     correlation_id: i32,
     client_id: &str,
     group_id: &str,
@@ -340,7 +340,7 @@ pub async fn heartbeat<T: BrokerConnection>(
 ///
 /// [protocol spec]: protocol::leave_group
 pub async fn leave_group<T: BrokerConnection>(
-    conn: T,
+    mut conn: T,
     correlation_id: i32,
     client_id: &str,
     group_id: &str,

--- a/src/consumer_group.rs
+++ b/src/consumer_group.rs
@@ -23,7 +23,7 @@ const DEFAULT_PROTOCOL_TYPE: &str = "consumer";
 
 #[derive(Clone, Debug)]
 pub struct ConsumerGroup<T: BrokerConnection> {
-    pub connection_params: ConnectionParams,
+    pub connection_params: ConnectionParams<T>,
     pub coordinator_conn: T,
     pub correlation_id: i32,
     pub client_id: String,

--- a/src/consumer_group_builder.rs
+++ b/src/consumer_group_builder.rs
@@ -101,7 +101,7 @@ impl<'a> ConsumerGroupBuilder {
         self
     }
 
-    pub async fn build<T: BrokerConnection>(self) -> Result<ConsumerGroup<T>> {
+    pub async fn build<T>(self) -> Result<ConsumerGroup<T>> {
         let conn = self.connection_params.init::<T>().await?;
         let coordinator =
             find_coordinator(conn, self.correlation_id, &self.client_id, &self.group_id).await?;

--- a/src/consumer_group_builder.rs
+++ b/src/consumer_group_builder.rs
@@ -101,8 +101,8 @@ impl<'a> ConsumerGroupBuilder {
         self
     }
 
-    pub async fn build<T>(self) -> Result<ConsumerGroup<T>> {
-        let conn = self.connection_params.init::<T>().await?;
+    pub async fn build<T: BrokerConnection>(self) -> Result<ConsumerGroup<T>> {
+        let conn = T::new(self.connection_params).await?;
         let coordinator =
             find_coordinator(conn, self.correlation_id, &self.client_id, &self.group_id).await?;
 
@@ -116,7 +116,7 @@ impl<'a> ConsumerGroupBuilder {
         })?;
         let port = coordinator.port;
         let coordinator_addr = format!("{}:{}", host, port);
-        let coordinator_conn = self.connection_params.from_url(coordinator_addr).await?;
+        let coordinator_conn = self.connection_params.from_url(coordinator_addr)?;
 
         Ok(ConsumerGroup {
             connection_params: self.connection_params,

--- a/src/consumer_group_builder.rs
+++ b/src/consumer_group_builder.rs
@@ -139,8 +139,8 @@ impl<'a> ConsumerGroupBuilder {
 /// See this [protocol spec] for more information.
 ///
 /// [protocol spec]: protocol::find_coordinator
-pub async fn find_coordinator(
-    conn: BrokerConnection,
+pub async fn find_coordinator<T: BrokerConnection>(
+    conn: T,
     correlation_id: i32,
     client_id: &str,
     group_id: &str,

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,7 @@ pub enum Error {
     AssignmentStrategyNotSupported(String),
     LockError(String),
     NotFound,
+    MissingBrokerConfigOptions
 }
 
 impl fmt::Display for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,7 +29,8 @@ pub enum Error {
     AssignmentStrategyNotSupported(String),
     LockError(String),
     NotFound,
-    MissingBrokerConfigOptions
+    MissingBrokerConfigOptions,
+    IncorrectConnectionUsage
 }
 
 impl fmt::Display for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,6 +457,8 @@ pub mod prelude {
     pub use crate::error::{Error, KafkaCode, Result};
     pub use crate::metadata::ClusterMetadata;
     pub use crate::network::BrokerConnection;
+    // #[cfg(feature = "tls")]
+    pub use crate::network::tls::{ConnectionOptions, TlsBrokerOptions, TlsConnection};
     pub use crate::producer::{produce, ProduceMessage, Producer};
     pub use crate::producer_builder::ProducerBuilder;
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -88,7 +88,7 @@ impl<'a, T: BrokerConnection + Debug + Copy> ClusterMetadata<T> {
             set.spawn(async move {
                 let id = broker.node_id;
                 let addr = broker.addr()?;
-                let conn = connection_params.init().await?;
+                let conn = connection_params.from_url(addr).await?;
                 Ok::<(i32, dyn BrokerConnection), Error>((id, conn))
             });
         }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -13,7 +13,7 @@ use crate::{
 
 #[derive(Clone, Default, Debug)]
 pub struct ClusterMetadata<T: BrokerConnection> {
-    pub connection_params: ConnectionParams,
+    pub connection_params: ConnectionParams<T>,
     pub broker_connections: HashMap<i32, T>,
     pub brokers: Vec<Broker>,
     pub topics: Vec<Topic>,
@@ -25,7 +25,7 @@ type TopicPartition = HashMap<String, Vec<i32>>;
 
 impl<'a, T: BrokerConnection + Debug + Copy> ClusterMetadata<T> {
     pub async fn new(
-        connection_params: ConnectionParams,
+        connection_params: ConnectionParams<T>,
         client_id: String,
         topics: Vec<String>,
     ) -> Result<ClusterMetadata<T>> {

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -35,11 +35,8 @@
 //! request that exceeds this limit will result in the socket being
 //! disconnected.
 
-
-pub mod tls;
 pub mod tcp;
+pub mod tls;
 
 // #[cfg(not(feature = "tls"))]
 pub type BrokerConnection = tcp::BrokerConnection;
-
-

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -55,13 +55,13 @@ pub enum ConnectionParamsKind {
     TlsParams(tls::ConnectionOptions)
 }
 
-pub struct ConnectionParams(ConnectionParamsKind);
+pub struct ConnectionParams<T: BrokerConnection>(ConnectionParamsKind);
 
-impl ConnectionParams {
-    async fn new(&self) -> Result<Box<dyn BrokerConnection>> {
+impl<T: BrokerConnection> ConnectionParams<T> {
+    async fn new(&self) -> Result<T> {
         match self.0 {
-            ConnectionParamsKind::TcpParams(bootstrap_addrs) => tcp::TcpConnection::new(bootstrap_addrs).await.map(|c| Box::new(c) as dyn BrokerConnection),
-            ConnectionParamsKind::TlsParams(options) => tls::TlsConnection::new(options).await.map(Box::new)
+            ConnectionParamsKind::TcpParams(bootstrap_addrs) => tcp::TcpConnection::new(bootstrap_addrs).await,
+            ConnectionParamsKind::TlsParams(options) => tls::TlsConnection::new(options).await
         }
     }
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -36,7 +36,6 @@
 //! disconnected.
 use crate::prelude::{Result, encode::ToByte};
 use bytes::BytesMut;
-use std::fmt::Debug;
 
 pub mod tcp;
 pub mod tls;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,0 +1,45 @@
+//! Connection & communication with a broker.
+//!
+//! # Network Module
+//!
+//! Kafka uses a binary protocol over TCP. The protocol defines all APIs as
+//! request response message pairs. All messages are size delimited and are
+//! made up of the following primitive types.
+//!
+//! The client initiates a socket connection and then writes a sequence of
+//! request messages and reads back the corresponding response message. No
+//! handshake is required on connection or disconnection. TCP is happier if
+//! you maintain persistent connections used for many requests to amortize
+//! the cost of the TCP handshake, but beyond this penalty connecting is
+//! pretty cheap.
+//!
+//! The client will likely need to maintain a connection to multiple brokers,
+//! as data is partitioned and the clients will need to talk to the server
+//! that has their data. However it should not generally be necessary to
+//! maintain multiple connections to a single broker from a single client
+//! instance (i.e. connection pooling).
+//!
+//! The server guarantees that on a single TCP connection, requests will
+//! be processed in the order they are sent and responses will return in
+//! that order as well. The broker's request processing allows only a
+//! single in-flight request per connection in order to guarantee this
+//! ordering. Note that clients can (and ideally should) use non-blocking
+//! IO to implement request pipelining and achieve higher throughput.
+//! i.e., clients can send requests even while awaiting responses for
+//! preceding requests since the outstanding requests will be buffered
+//! in the underlying OS socket buffer. All requests are initiated by
+//! the client, and result in a corresponding response message from the
+//! server except where noted.
+//!
+//! The server has a configurable maximum limit on request size and any
+//! request that exceeds this limit will result in the socket being
+//! disconnected.
+
+
+pub mod tls;
+pub mod tcp;
+
+// #[cfg(not(feature = "tls"))]
+pub type BrokerConnection = tcp::BrokerConnection;
+
+

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -45,32 +45,7 @@ pub mod tls;
 // pub type BrokerConnection = tcp::BrokerConnection;
 
 pub trait BrokerConnection {
-    async fn send_request<R: ToByte>(&self, req: &R) -> Result<()> {}
-    async fn receive_response(&mut self) -> Result<BytesMut> {}
-}
-
-impl BrokerConnection for tls::TlsConnection {
-    async fn send_request<R: ToByte>(&self, req: &R) -> Result<()> {
-        self.send_request(req)
-    }
-
-    async fn receive_response(&mut self) -> Result<BytesMut> {
-        self.receive_response()
-    }
-}
-
-impl BrokerConnection for tcp::TcpConnection {
-    async fn send_request<R: ToByte>(&self, req: &R) -> Result<()> {
-        self.send_request(req)
-    }
-
-    async fn receive_response(&mut self) -> Result<BytesMut> {
-        self.receive_response()
-    }
-}
-
-impl Debug for dyn BrokerConnection {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Series{{{}}}", self.len())
-    }
+    // async fn new<T>(options: T) -> Result<Self> {}
+    async fn send_request<R: ToByte>(&self, req: &R) -> Result<()>;
+    async fn receive_response(&mut self) -> Result<BytesMut>;
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -34,9 +34,43 @@
 //! The server has a configurable maximum limit on request size and any
 //! request that exceeds this limit will result in the socket being
 //! disconnected.
+use crate::prelude::{Result, encode::ToByte};
+use bytes::BytesMut;
+use std::fmt::Debug;
 
 pub mod tcp;
 pub mod tls;
 
 // #[cfg(not(feature = "tls"))]
-pub type BrokerConnection = tcp::BrokerConnection;
+// pub type BrokerConnection = tcp::BrokerConnection;
+
+pub trait BrokerConnection {
+    async fn send_request<R: ToByte>(&self, req: &R) -> Result<()> {}
+    async fn receive_response(&mut self) -> Result<BytesMut> {}
+}
+
+impl BrokerConnection for tls::TlsConnection {
+    async fn send_request<R: ToByte>(&self, req: &R) -> Result<()> {
+        self.send_request(req)
+    }
+
+    async fn receive_response(&mut self) -> Result<BytesMut> {
+        self.receive_response()
+    }
+}
+
+impl BrokerConnection for tcp::TcpConnection {
+    async fn send_request<R: ToByte>(&self, req: &R) -> Result<()> {
+        self.send_request(req)
+    }
+
+    async fn receive_response(&mut self) -> Result<BytesMut> {
+        self.receive_response()
+    }
+}
+
+impl Debug for dyn BrokerConnection {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Series{{{}}}", self.len())
+    }
+}

--- a/src/network/tcp.rs
+++ b/src/network/tcp.rs
@@ -119,8 +119,10 @@ impl TcpConnection {
             }
         }
     }
+}
 
-    /// Serialize a given request and send to Kafka/Redpanda broker.
+impl super::BrokerConnection for TcpConnection {
+/// Serialize a given request and send to Kafka/Redpanda broker.
     ///
     /// The Kafka protocol specifies that all requests will
     /// be processed in the order they are sent and responses will return in
@@ -136,7 +138,7 @@ impl TcpConnection {
     /// let buf = "test";
     /// conn.send_request(buf).await?;
     /// ```
-    pub async fn send_request<R: ToByte>(&mut self, req: &R) -> Result<()> {
+    async fn send_request<R: ToByte>(&self, req: &R) -> Result<()> {
         // TODO: Does it make sense to find the capacity of the type
         // and fill it here?
         let mut buffer = Vec::with_capacity(4);
@@ -167,7 +169,7 @@ impl TcpConnection {
     /// // receive a message from a kafka broker
     /// let response_bytes = conn.receive_response().await?;
     /// ```
-    pub async fn receive_response(&mut self) -> Result<BytesMut> {
+    async fn receive_response(&mut self) -> Result<BytesMut> {
         // figure out the message size
         let mut size = self.read(4).await?;
 

--- a/src/network/tcp.rs
+++ b/src/network/tcp.rs
@@ -10,6 +10,8 @@ use crate::{
     error::{Error, Result},
 };
 
+use super::{ConnectionParams, ConnectionParamsKind};
+
 
 /// Reference counted TCP connection to a Kafka/Redpanda broker.
 ///
@@ -123,6 +125,13 @@ impl TcpConnection {
 }
 
 impl super::BrokerConnection for TcpConnection {
+    async fn new(p: ConnectionParams) -> Result<Self> {
+        match p.0 {
+            ConnectionParamsKind::TcpParams(p) => Self::new(p).await,
+            _ => panic!("You have used the wrong type")
+        }
+    }
+    
     /// Serialize a given request and send to Kafka/Redpanda broker.
     ///
     /// The Kafka protocol specifies that all requests will

--- a/src/network/tcp.rs
+++ b/src/network/tcp.rs
@@ -1,46 +1,10 @@
-//! Connection & communication with a broker.
-//!
-//! # Network Module
-//!
-//! Kafka uses a binary protocol over TCP. The protocol defines all APIs as
-//! request response message pairs. All messages are size delimited and are
-//! made up of the following primitive types.
-//!
-//! The client initiates a socket connection and then writes a sequence of
-//! request messages and reads back the corresponding response message. No
-//! handshake is required on connection or disconnection. TCP is happier if
-//! you maintain persistent connections used for many requests to amortize
-//! the cost of the TCP handshake, but beyond this penalty connecting is
-//! pretty cheap.
-//!
-//! The client will likely need to maintain a connection to multiple brokers,
-//! as data is partitioned and the clients will need to talk to the server
-//! that has their data. However it should not generally be necessary to
-//! maintain multiple connections to a single broker from a single client
-//! instance (i.e. connection pooling).
-//!
-//! The server guarantees that on a single TCP connection, requests will
-//! be processed in the order they are sent and responses will return in
-//! that order as well. The broker's request processing allows only a
-//! single in-flight request per connection in order to guarantee this
-//! ordering. Note that clients can (and ideally should) use non-blocking
-//! IO to implement request pipelining and achieve higher throughput.
-//! i.e., clients can send requests even while awaiting responses for
-//! preceding requests since the outstanding requests will be buffered
-//! in the underlying OS socket buffer. All requests are initiated by
-//! the client, and result in a corresponding response message from the
-//! server except where noted.
-//!
-//! The server has a configurable maximum limit on request size and any
-//! request that exceeds this limit will result in the socket being
-//! disconnected.
-
 use std::io::ErrorKind;
 use std::{io, sync::Arc};
 
 use bytes::{Buf, BytesMut};
 use tokio::net::TcpStream;
 use tracing::instrument;
+
 
 use crate::{
     encode::ToByte,

--- a/src/network/tcp.rs
+++ b/src/network/tcp.rs
@@ -10,7 +10,6 @@ use crate::{
     error::{Error, Result},
 };
 
-use super::ConnectionParams;
 
 /// Reference counted TCP connection to a Kafka/Redpanda broker.
 ///

--- a/src/network/tcp.rs
+++ b/src/network/tcp.rs
@@ -10,6 +10,8 @@ use crate::{
     error::{Error, Result},
 };
 
+use super::ConnectionParams;
+
 /// Reference counted TCP connection to a Kafka/Redpanda broker.
 ///
 /// This is designed to be held by a metadata structure which will
@@ -122,7 +124,7 @@ impl TcpConnection {
 }
 
 impl super::BrokerConnection for TcpConnection {
-/// Serialize a given request and send to Kafka/Redpanda broker.
+    /// Serialize a given request and send to Kafka/Redpanda broker.
     ///
     /// The Kafka protocol specifies that all requests will
     /// be processed in the order they are sent and responses will return in
@@ -138,7 +140,7 @@ impl super::BrokerConnection for TcpConnection {
     /// let buf = "test";
     /// conn.send_request(buf).await?;
     /// ```
-    async fn send_request<R: ToByte>(&self, req: &R) -> Result<()> {
+    async fn send_request<R: ToByte>(&mut self, req: &R) -> Result<()> {
         // TODO: Does it make sense to find the capacity of the type
         // and fill it here?
         let mut buffer = Vec::with_capacity(4);

--- a/src/network/tcp.rs
+++ b/src/network/tcp.rs
@@ -5,7 +5,6 @@ use bytes::{Buf, BytesMut};
 use tokio::net::TcpStream;
 use tracing::instrument;
 
-
 use crate::{
     encode::ToByte,
     error::{Error, Result},

--- a/src/network/tls.rs
+++ b/src/network/tls.rs
@@ -1,0 +1,221 @@
+use std::fs::File;
+use std::io::BufReader;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::{
+    io,
+    sync::{Arc, Mutex},
+};
+
+use bytes::{Buf, BytesMut};
+use rustls_pemfile::{certs, pkcs8_private_keys};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer};
+use std::net::ToSocketAddrs;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio_rustls::{client::TlsStream, rustls, TlsConnector};
+use tracing::instrument;
+
+use crate::{
+    encode::ToByte,
+    error::{Error, Result},
+};
+
+/// Reference counted TCP connection to a Kafka/Redpanda broker.
+///
+/// This is designed to be held by a metadata structure which will
+/// dispatch many of these connections at the behest of either a
+/// consumer or producer.
+///
+/// A client would probably need more than one of these at a given time
+/// to implement all of the different protocols.
+///
+/// Typically this would only be used directly in a low level context.
+/// Otherwise the Metadata, Consumer, or Producer modules abstract out the
+/// connection details for the user.
+
+#[derive(Clone, Debug)]
+pub struct TlsConnection {
+    stream: Arc<Mutex<TlsStream<TcpStream>>>,
+}
+
+pub struct ConnectionOptions {
+    pub broker_options: Vec<TlsBrokerOptions>,
+    pub cafile: Option<PathBuf>,
+}
+
+pub struct TlsBrokerOptions {
+    pub host: String,
+    pub port: u16,
+    pub key: PathBuf,
+    pub cert: PathBuf,
+}
+
+impl TlsConnection {
+    /// Connect to a Kafka/Redpanda broker
+    ///
+    /// ### Example
+    /// ```
+    /// // connect to a kafka/redpanda broker
+    /// let addrs = vec!["localhost:9092"];
+    /// let conn = samsa::prelude::BrokerConnection(addrs).await?;
+    /// ```
+    pub async fn new(options: ConnectionOptions) -> Result<Self> {
+        tracing::debug!(
+            "Starting connection to {} brokers",
+            options.broker_options.len()
+        );
+        let mut propagated_err: Option<Error> = None;
+
+        // need to figure out what this is
+        let mut root_cert_store = rustls::RootCertStore::empty();
+        if let Some(cafile) = &options.cafile {
+            let mut pem = BufReader::new(File::open(cafile).unwrap());
+            for cert in rustls_pemfile::certs(&mut pem) {
+                root_cert_store.add(cert.unwrap()).unwrap();
+            }
+        } else {
+            root_cert_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        }
+
+        for broker_option in options.broker_options.iter() {
+            let addr = (broker_option.host.as_str(), broker_option.port)
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .ok_or_else(|| Error::IoError(ErrorKind::NotFound))
+                .unwrap();
+
+            tracing::debug!("Connecting to {}", broker_option.host);
+            let certs = load_certs(&broker_option.cert).map_err(|e| Error::IoError(e.kind()))?;
+            let key = load_keys(&broker_option.key).map_err(|e| Error::IoError(e.kind()))?;
+            tracing::debug!("keys ready");
+
+            match TcpStream::connect(addr).await {
+                Ok(s) => {
+                    tracing::debug!("connected on tcp");
+
+                    let config = rustls::ClientConfig::builder()
+                        .with_root_certificates(root_cert_store)
+                        .with_client_auth_cert(certs, key)
+                        .unwrap();
+
+                    let connector = TlsConnector::from(Arc::new(config));
+                    tracing::debug!("tls connected");
+
+                    let domain = rustls_pki_types::ServerName::try_from(broker_option.host.clone())
+                        .map_err(|_| Error::IoError(ErrorKind::InvalidInput))?
+                        .to_owned();
+                    tracing::debug!("dns ready");
+
+                    let stream = connector
+                        .connect(domain, s)
+                        .await
+                        .map_err(|e| Error::IoError(e.kind()))?;
+                    tracing::debug!("tls connected to tcp");
+
+                    return Ok(Self {
+                        stream: Arc::new(Mutex::new(stream)),
+                    });
+                }
+                Err(e) => {
+                    propagated_err = Some(Error::IoError(e.kind()));
+                }
+            }
+        }
+
+        // if there was an error, report it
+        if let Some(e) = propagated_err {
+            return Err(e);
+        }
+        return Err(Error::IoError(ErrorKind::NotFound));
+    }
+
+    /// Serialize a given request and send to Kafka/Redpanda broker.
+    ///
+    /// The Kafka protocol specifies that all requests will
+    /// be processed in the order they are sent and responses will return in
+    /// that order as well. Users of this method should be sure to use the receive_response method
+    /// to accept Kafka responses in the order that these requests are sent.
+    ///
+    /// This method is only useful in practice when used in combination with
+    /// a request type. To see how this would be done, visit the protocol module.
+    ///
+    /// ### Example
+    /// ```
+    /// // send an arbitrary set of bytes to kafka broker
+    /// let buf = "test";
+    /// conn.send_request(buf).await?;
+    /// ```
+    pub async fn send_request<R: ToByte>(&self, req: &R) -> Result<()> {
+        // TODO: Does it make sense to find the capacity of the type
+        // and fill it here?
+        let mut buffer = Vec::with_capacity(4);
+
+        buffer.extend_from_slice(&[0, 0, 0, 0]);
+        req.encode(&mut buffer)?;
+
+        let size = buffer.len() as i32 - 4;
+        size.encode(&mut &mut buffer[..])?;
+
+        tracing::trace!("Sending bytes {}", buffer.len());
+        self.stream
+            .lock()
+            .map_err(|_| Error::IoError(ErrorKind::Other))?
+            .write_all(&buffer)
+            .await
+            .map_err(|e| Error::IoError(e.kind()))?;
+
+        Ok(())
+    }
+
+    /// Receive a response in raw bytes from a Kafka/Redpanda broker.
+    ///
+    /// Kafka queues up responses on the socket as requests are sent by the client.
+    /// This method pulls 1 request off the socket at a time and returns the raw bytes.
+    ///
+    /// This method returns raw data that is not useful until parsed
+    /// into a response type. To see how this would be done, visit the
+    /// protocol module.
+    ///
+    /// ### Example
+    /// ```
+    /// // receive a message from a kafka broker
+    /// let response_bytes = conn.receive_response().await?;
+    /// ```
+    pub async fn receive_response(&mut self) -> Result<BytesMut> {
+        // figure out the message size
+        let mut stream = self
+            .stream
+            .lock()
+            .map_err(|_| Error::IoError(ErrorKind::Other))?;
+
+        let length = stream
+            .read_u32()
+            .await
+            .map_err(|e| Error::IoError(e.kind()))?;
+
+        tracing::trace!("Reading {} bytes", length);
+        let mut buffer = BytesMut::zeroed(length as usize);
+        tracing::trace!("before {:?}", buffer);
+
+        stream
+            .read_exact(&mut buffer)
+            .await
+            .map_err(|e| Error::IoError(e.kind()))?;
+        tracing::trace!("Read {:?}", buffer);
+
+        Ok(buffer)
+    }
+}
+
+fn load_certs(path: &Path) -> io::Result<Vec<CertificateDer<'static>>> {
+    certs(&mut BufReader::new(File::open(path)?)).collect()
+}
+
+fn load_keys(path: &Path) -> io::Result<PrivateKeyDer<'static>> {
+    pkcs8_private_keys(&mut BufReader::new(File::open(path)?))
+        .next()
+        .unwrap()
+        .map(Into::into)
+}

--- a/src/network/tls.rs
+++ b/src/network/tls.rs
@@ -21,7 +21,7 @@ use crate::{
     error::{Error, Result},
 };
 
-use super::ConnectionParams;
+use super::{ConnectionParams, ConnectionParamsKind};
 
 /// Reference counted TCP connection to a Kafka/Redpanda broker.
 ///
@@ -47,6 +47,7 @@ pub struct ConnectionOptions {
     pub cafile: Option<PathBuf>,
 }
 
+#[derive(Clone, Debug)]
 pub struct TlsBrokerOptions {
     pub host: String,
     pub port: u16,
@@ -148,6 +149,12 @@ fn load_keys(path: &Path) -> io::Result<PrivateKeyDer<'static>> {
 
 
 impl super::BrokerConnection for TlsConnection {
+    async fn new(p: ConnectionParams) -> Result<Self> {
+        match p.0 {
+            ConnectionParamsKind::TlsParams(p) => Self::new(p).await,
+            _ => panic!("You have used the wrong type")
+        }
+    }
 
     /// Serialize a given request and send to Kafka/Redpanda broker.
     ///

--- a/src/network/tls.rs
+++ b/src/network/tls.rs
@@ -21,6 +21,8 @@ use crate::{
     error::{Error, Result},
 };
 
+use super::ConnectionParams;
+
 /// Reference counted TCP connection to a Kafka/Redpanda broker.
 ///
 /// This is designed to be held by a metadata structure which will
@@ -145,6 +147,7 @@ fn load_keys(path: &Path) -> io::Result<PrivateKeyDer<'static>> {
 
 
 impl super::BrokerConnection for TlsConnection {
+
     /// Serialize a given request and send to Kafka/Redpanda broker.
     ///
     /// The Kafka protocol specifies that all requests will
@@ -161,7 +164,7 @@ impl super::BrokerConnection for TlsConnection {
     /// let buf = "test";
     /// conn.send_request(buf).await?;
     /// ```
-    async fn send_request<R: ToByte>(&self, req: &R) -> Result<()> {
+    async fn send_request<R: ToByte>(&mut self, req: &R) -> Result<()> {
         // TODO: Does it make sense to find the capacity of the type
         // and fill it here?
         let mut buffer = Vec::with_capacity(4);

--- a/src/network/tls.rs
+++ b/src/network/tls.rs
@@ -41,6 +41,7 @@ pub struct TlsConnection {
     stream: Arc<Mutex<TlsStream<TcpStream>>>,
 }
 
+#[derive(Clone, Debug)]
 pub struct ConnectionOptions {
     pub broker_options: Vec<TlsBrokerOptions>,
     pub cafile: Option<PathBuf>,

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -159,8 +159,8 @@ pub(crate) async fn flush_producer(
 /// Produce messages to a broker.
 ///
 /// See this [protocol spec](crate::prelude::protocol::produce) for more information.
-pub async fn produce(
-    broker_conn: BrokerConnection,
+pub async fn produce<T: BrokerConnection>(
+    broker_conn: T,
     correlation_id: i32,
     client_id: &str,
     required_acks: i16,

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1,6 +1,6 @@
 //! Client that sends records to a cluster.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Debug};
 
 use bytes::Bytes;
 use tokio::{
@@ -101,8 +101,8 @@ impl Producer {
 
 // vector for the results from each broker
 #[instrument(skip(messages, produce_params, cluster_metadata))]
-pub(crate) async fn flush_producer(
-    cluster_metadata: &ClusterMetadata,
+pub(crate) async fn flush_producer<T: BrokerConnection + Debug + Copy + Send + 'static>(
+    cluster_metadata: &ClusterMetadata<T>,
     produce_params: &ProduceParams,
     messages: Vec<ProduceMessage>,
 ) -> Result<Vec<Option<ProduceResponse>>> {
@@ -135,7 +135,7 @@ pub(crate) async fn flush_producer(
         let p = produce_params.clone();
         set.spawn(async move {
             produce(
-                broker_conn.to_owned(),
+                broker_conn,
                 p.correlation_id,
                 &p.client_id,
                 p.required_acks,
@@ -160,7 +160,7 @@ pub(crate) async fn flush_producer(
 ///
 /// See this [protocol spec](crate::prelude::protocol::produce) for more information.
 pub async fn produce<T: BrokerConnection>(
-    broker_conn: T,
+    mut broker_conn: T,
     correlation_id: i32,
     client_id: &str,
     required_acks: i16,

--- a/src/producer_builder.rs
+++ b/src/producer_builder.rs
@@ -1,8 +1,10 @@
+use std::fmt::Debug;
 use std::time::Duration;
 
 use tokio::sync::mpsc::{channel, unbounded_channel, Receiver, UnboundedSender};
 use tokio_stream::{Stream, StreamExt};
 
+use crate::network::{BrokerConnection, ConnectionParams};
 use crate::producer::{flush_producer, ProduceMessage, ProduceParams, Producer};
 use crate::protocol::ProduceResponse;
 use crate::{error::Result, metadata::ClusterMetadata, DEFAULT_CLIENT_ID};
@@ -39,18 +41,18 @@ const DEFAULT_BATCH_TIMEOUT_MS: u64 = 1000;
 ///     .await;
 /// ```
 #[derive(Clone)]
-pub struct ProducerBuilder {
-    cluster_metadata: ClusterMetadata,
+pub struct ProducerBuilder<T: BrokerConnection> {
+    cluster_metadata: ClusterMetadata<T>,
     produce_params: ProduceParams,
     max_batch_size: usize,
     batch_timeout_ms: u64,
 }
 
-impl<'a> ProducerBuilder {
+impl<'a, T: BrokerConnection + Debug + Copy + Send + Sync + 'static> ProducerBuilder<T> {
     /// Start a producer builder. To complete, use the [`build`](Self::build) method.
-    pub async fn new(bootstrap_addrs: Vec<String>, topics: Vec<String>) -> Result<Self> {
+    pub async fn new(connection_params: ConnectionParams, topics: Vec<String>) -> Result<Self> {
         let cluster_metadata =
-            ClusterMetadata::new(bootstrap_addrs, DEFAULT_CLIENT_ID.to_owned(), topics).await?;
+            ClusterMetadata::new(connection_params, DEFAULT_CLIENT_ID.to_owned(), topics).await?;
 
         Ok(Self {
             cluster_metadata,
@@ -162,10 +164,10 @@ fn into_produce_stream(
     }
 }
 
-async fn producer(
+async fn producer<T: BrokerConnection + Debug + Copy + Send + 'static>(
     stream: impl Stream<Item = Vec<ProduceMessage>> + Send + 'static,
     output_sender: UnboundedSender<Vec<Option<ProduceResponse>>>,
-    cluster_metadata: ClusterMetadata,
+    cluster_metadata: ClusterMetadata<T>,
     produce_params: ProduceParams,
 ) {
     tokio::pin!(stream);

--- a/src/producer_builder.rs
+++ b/src/producer_builder.rs
@@ -50,7 +50,7 @@ pub struct ProducerBuilder<T: BrokerConnection> {
 
 impl<'a, T: BrokerConnection + Debug + Copy + Send + Sync + 'static> ProducerBuilder<T> {
     /// Start a producer builder. To complete, use the [`build`](Self::build) method.
-    pub async fn new(connection_params: ConnectionParams<T>, topics: Vec<String>) -> Result<Self> {
+    pub async fn new(connection_params: ConnectionParams, topics: Vec<String>) -> Result<Self> {
         let cluster_metadata =
             ClusterMetadata::new(connection_params, DEFAULT_CLIENT_ID.to_owned(), topics).await?;
 

--- a/src/producer_builder.rs
+++ b/src/producer_builder.rs
@@ -50,7 +50,7 @@ pub struct ProducerBuilder<T: BrokerConnection> {
 
 impl<'a, T: BrokerConnection + Debug + Copy + Send + Sync + 'static> ProducerBuilder<T> {
     /// Start a producer builder. To complete, use the [`build`](Self::build) method.
-    pub async fn new(connection_params: ConnectionParams, topics: Vec<String>) -> Result<Self> {
+    pub async fn new(connection_params: ConnectionParams<T>, topics: Vec<String>) -> Result<Self> {
         let cluster_metadata =
             ClusterMetadata::new(connection_params, DEFAULT_CLIENT_ID.to_owned(), topics).await?;
 


### PR DESCRIPTION
Requesting Help:

I think there are 3 cases in which we need to alter our code so that we can abstract away the TCP/TLS connection to brokers

First are the lower level protocol method, like found in the `src/admin.rs` file which just accept a connection and then use it. This I believe is solved because we can use a trait and a generic. That is what I have done in this PR so far

Second is the Cluster metadata getting instantiated in `src/metadata.rs`. We iterate over the broker_addrs and call `BrokerConnection::new(url)`. If BrokerConnection is a trait, we don't have `new` (I thought about adding it but the two structs need different args), so that is a challenge. I considered making the ClusterMetadata args be a generic as well but there is no common functionality between the params so I need to look deeper into it.

Third is the structs that use the ClusterMetadata. I was thinking that we can just pass in an instantiated metadata struct when we instantiate a producer or whatever. And then we can build on top of that to have like a Producer<TlsConnection> or a Consumer<TcpConnection>. Maybe that is leaky? idk