### PR TITLE
Make logs be a bit quieter

### DIFF
--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -253,7 +253,7 @@ impl<'a, T: BrokerConnection + Clone + Debug + 'a> Consumer<T> {
             }
         }
 
-        tracing::info!(
+        tracing::debug!(
             "Read {} records, newest offset {:?}",
             records.len(),
             self.offsets

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -108,7 +108,7 @@ pub(crate) async fn flush_producer<T: BrokerConnection + Clone + Debug + Send + 
     attributes: Attributes,
 ) -> Result<Vec<Option<ProduceResponse>>> {
     let mut brokers_and_messages = HashMap::new();
-    tracing::info!("Producing {} messages", messages.len());
+    tracing::debug!("Producing {} messages", messages.len());
     for message in messages {
         let broker_id = cluster_metadata
             .get_leader_for_topic_partition(&message.topic, message.partition_id)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,11 +29,10 @@ pub fn uncompress<T: Read>(src: T) -> Result<Vec<u8>> {
     let mut d = GzDecoder::new(src);
 
     let mut buffer: Vec<u8> = Vec::new();
-    d.read_to_end(&mut buffer)
-        .map_err(|e| {
-            tracing::error!("Error uncompressing buffer {:?}", e);
-            Error::IoError(e.kind())
-        })?;
+    d.read_to_end(&mut buffer).map_err(|e| {
+        tracing::error!("Error uncompressing buffer {:?}", e);
+        Error::IoError(e.kind())
+    })?;
     Ok(buffer)
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,7 +30,10 @@ pub fn uncompress<T: Read>(src: T) -> Result<Vec<u8>> {
 
     let mut buffer: Vec<u8> = Vec::new();
     d.read_to_end(&mut buffer)
-        .map_err(|e| Error::IoError(e.kind()))?;
+        .map_err(|e| {
+            tracing::error!("Error uncompressing buffer {:?}", e);
+            Error::IoError(e.kind())
+        })?;
     Ok(buffer)
 }
 


### PR DESCRIPTION
When running examples, you get a lot of noise from the library logs. There is no need for our lib to use the `info` level logging, so I changed them to `debug`.