### PR TITLE
Hgk/fix integration tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,6 +463,7 @@ pub mod prelude {
     };
     pub use crate::producer::{produce, ProduceMessage, Producer};
     pub use crate::producer_builder::ProducerBuilder;
+    pub use crate::protocol::Header;
 
     pub use bytes;
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -63,9 +63,7 @@ impl<'a, T: BrokerConnection + Clone + Debug> ClusterMetadata<T> {
             .find(|b| b.partition_index == partition_id)
     }
 
-    pub fn get_leader_id_for_cluster(
-        &self,
-    ) -> i32 {
+    pub fn get_leader_id_for_cluster(&self) -> i32 {
         self.controller_id
     }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -18,6 +18,7 @@ pub struct ClusterMetadata<T: BrokerConnection> {
     pub topics: Vec<Topic>,
     pub client_id: String,
     pub topic_names: Vec<String>,
+    pub controller_id: i32,
 }
 
 type TopicPartition = HashMap<String, Vec<i32>>;
@@ -31,6 +32,7 @@ impl<'a, T: BrokerConnection + Clone + Debug> ClusterMetadata<T> {
         // tracing::info!("Conencting to cluster at {}", bootstrap_addrs.join(","));
         let mut metadata = ClusterMetadata {
             connection_params: connection_params.clone(),
+            controller_id: -1,
             broker_connections: HashMap::new(),
             brokers: vec![],
             topics: vec![],
@@ -61,7 +63,13 @@ impl<'a, T: BrokerConnection + Clone + Debug> ClusterMetadata<T> {
             .find(|b| b.partition_index == partition_id)
     }
 
-    pub fn get_leader_for_topic_partition(
+    pub fn get_leader_id_for_cluster(
+        &self,
+    ) -> i32 {
+        self.controller_id
+    }
+
+    pub fn get_leader_id_for_topic_partition(
         &self,
         topic_name: &'a str,
         partition_id: i32,
@@ -114,6 +122,7 @@ impl<'a, T: BrokerConnection + Clone + Debug> ClusterMetadata<T> {
 
         self.topics = metadata_response.topics;
         self.brokers = metadata_response.brokers;
+        self.controller_id = metadata_response.controller_id;
 
         Ok(())
     }
@@ -143,10 +152,8 @@ impl<'a, T: BrokerConnection + Clone + Debug> ClusterMetadata<T> {
         Ok(connections)
     }
 
-    // Given topics and partitions
-    // get back a map where
-    // broker connection is the key
-    // and value is a list of tuples of (topic, partitions)
+    /// Given topics and partitions, get back a map where broker connection is the key
+    /// and value is a list of tuples of (topic, partitions)
     pub fn get_leaders_for_topic_partitions(
         &'a self,
         topic_partitions: &TopicPartition,
@@ -164,7 +171,7 @@ impl<'a, T: BrokerConnection + Clone + Debug> ClusterMetadata<T> {
             })
             // Attach each partition with its appropriate broker
             .map(|(new_topic_name, new_partition)| {
-                match self.get_leader_for_topic_partition(&new_topic_name, *new_partition) {
+                match self.get_leader_id_for_topic_partition(&new_topic_name, *new_partition) {
                     Some(broker_id) => Ok((new_topic_name, new_partition, broker_id)),
                     None => Err(Error::MetadataNeedsSync),
                 }
@@ -237,21 +244,25 @@ mod test {
                 broker_connections: HashMap::new(),
                 topic_names: vec![String::from("purchases")],
                 client_id: String::from("client_id"),
+                controller_id: 1,
                 brokers: vec![
                     Broker {
                         node_id: 1,
                         host: Bytes::from("localhost"),
                         port: 9092,
+                        rack: None,
                     },
                     Broker {
                         node_id: 2,
                         host: Bytes::from("localhost"),
                         port: 9093,
+                        rack: None,
                     },
                 ],
                 topics: vec![Topic {
                     error_code: KafkaCode::None,
                     name: Bytes::from("purchases"),
+                    is_internal: false,
                     partitions: vec![
                         Partition {
                             error_code: KafkaCode::None,
@@ -313,6 +324,7 @@ mod test {
             node_id: 2,
             host: Bytes::from("localhost"),
             port: 9093,
+            rack: None,
         };
         assert_eq!(
             broker.addr().unwrap(),
@@ -327,12 +339,12 @@ mod test {
     fn test_partition_leader() {
         let cluster: ClusterMetadata<TcpConnection> = test_metadata!();
 
-        let leader = cluster.get_leader_for_topic_partition("purchases", 1);
+        let leader = cluster.get_leader_id_for_topic_partition("purchases", 1);
 
         assert!(leader.is_some());
         assert_eq!(leader.unwrap(), 1);
 
-        let leader = cluster.get_leader_for_topic_partition("purchases", 0);
+        let leader = cluster.get_leader_id_for_topic_partition("purchases", 0);
 
         assert!(leader.is_some());
         assert_eq!(leader.unwrap(), 2);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -97,12 +97,7 @@ where
 
 pub fn parse_boolean(s: NomBytes) -> IResult<NomBytes, bool> {
     let (s, b) = take(1_usize)(s)?;
-    let b: bool = if b == NomBytes::from(b"\x00" as &[u8]) {
-        false
-    } else {
-        true
-    };
-
+    let b = b != NomBytes::from(b"\x00" as &[u8]);
     Ok((s, b))
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -174,21 +174,21 @@ mod test {
     fn test_parse_bool_false() {
         let buf = NomBytes::from(b"\x00" as &[u8]);
 
-        assert_eq!(parse_boolean(buf).unwrap().1, false);
+        assert!(!parse_boolean(buf).unwrap().1);
     }
 
     #[test]
     fn test_parse_bool_true() {
         let buf = NomBytes::from(b"\x01" as &[u8]);
 
-        assert_eq!(parse_boolean(buf).unwrap().1, true);
+        assert!(parse_boolean(buf).unwrap().1);
     }
 
     #[test]
     fn test_parse_bool_two() {
         let buf = NomBytes::from(b"\x02" as &[u8]);
 
-        assert_eq!(parse_boolean(buf).unwrap().1, true);
+        assert!(parse_boolean(buf).unwrap().1);
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -95,6 +95,17 @@ where
     }
 }
 
+pub fn parse_boolean(s: NomBytes) -> IResult<NomBytes, bool> {
+    let (s, b) = take(1_usize)(s)?;
+    let b: bool = if b == NomBytes::from(b"\x00" as &[u8]) {
+        false
+    } else {
+        true
+    };
+
+    Ok((s, b))
+}
+
 pub fn parse_nullable_string(s: NomBytes) -> IResult<NomBytes, Option<Bytes>> {
     let (s, length) = be_i16(s)?;
     if length == -1 {
@@ -157,6 +168,27 @@ mod test {
             parse_string(buf).unwrap().1,
             NomBytes::from(b"\x72\x75\x73\x74" as &[u8]).to_bytes()
         );
+    }
+
+    #[test]
+    fn test_parse_bool_false() {
+        let buf = NomBytes::from(b"\x00" as &[u8]);
+
+        assert_eq!(parse_boolean(buf).unwrap().1, false);
+    }
+
+    #[test]
+    fn test_parse_bool_true() {
+        let buf = NomBytes::from(b"\x01" as &[u8]);
+
+        assert_eq!(parse_boolean(buf).unwrap().1, true);
+    }
+
+    #[test]
+    fn test_parse_bool_two() {
+        let buf = NomBytes::from(b"\x02" as &[u8]);
+
+        assert_eq!(parse_boolean(buf).unwrap().1, true);
     }
 
     #[test]

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -111,7 +111,7 @@ pub(crate) async fn flush_producer<T: BrokerConnection + Clone + Debug + Send + 
     tracing::debug!("Producing {} messages", messages.len());
     for message in messages {
         let broker_id = cluster_metadata
-            .get_leader_for_topic_partition(&message.topic, message.partition_id)
+            .get_leader_id_for_topic_partition(&message.topic, message.partition_id)
             .ok_or(Error::NoLeaderForTopicPartition(
                 message.topic.clone(),
                 message.partition_id,

--- a/src/protocol/metadata/mod.rs
+++ b/src/protocol/metadata/mod.rs
@@ -28,13 +28,14 @@ mod test {
     use bytes::Bytes;
     use nombytes::NomBytes;
 
+    use super::response::*;
     use super::*;
     use crate::{encode::ToByte, error::KafkaCode, protocol};
 
     #[test]
     fn encode() {
         let b = [
-            0, 3, 0, 0, 0, 0, 0, 1, 0, 4, 114, 117, 115, 116, 0, 0, 0, 1, 0, 9, 112, 117, 114, 99,
+            0, 3, 0, 1, 0, 0, 0, 1, 0, 4, 114, 117, 115, 116, 0, 0, 0, 1, 0, 9, 112, 117, 114, 99,
             104, 97, 115, 101, 115,
         ];
         let correlation_id = 1;
@@ -52,15 +53,7 @@ mod test {
 
     #[test]
     fn parse() {
-        let buf = [
-            0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 1, 0, 9, 108, 111, 99, 97, 108, 104, 111, 115, 116, 0,
-            0, 35, 132, 0, 0, 0, 2, 0, 9, 108, 111, 99, 97, 108, 104, 111, 115, 116, 0, 0, 35, 133,
-            0, 0, 0, 1, 0, 0, 0, 9, 112, 117, 114, 99, 104, 97, 115, 101, 115, 0, 0, 0, 4, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 1,
-            0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 2, 0, 0, 0,
-            2, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 3, 0, 0, 0, 1, 0, 0,
-            0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1,
-        ];
+        let buf = b"\0\0\0\x01\0\0\0\x02\0\0\0\x01\0\tlocalhost\0\0#\x84\xff\xff\0\0\0\x02\0\tlocalhost\0\0#\x85\xff\xff\0\0\0\x01\0\0\0\x01\0\0\0\tbenchmark\0\0\0\0\x03\0\0\0\0\0\0\0\0\0\x02\0\0\0\x01\0\0\0\x02\0\0\0\x01\0\0\0\x02\0\0\0\0\0\x01\0\0\0\x02\0\0\0\x01\0\0\0\x02\0\0\0\x01\0\0\0\x02\0\0\0\0\0\x02\0\0\0\x01\0\0\0\x01\0\0\0\x01\0\0\0\x01\0\0\0\x01";
         let res = test_metadata();
 
         let (_, parsed) =
@@ -68,49 +61,46 @@ mod test {
         assert_eq!(parsed, res);
     }
 
-    fn test_metadata() -> response::MetadataResponse {
-        response::MetadataResponse {
+    fn test_metadata() -> MetadataResponse {
+        MetadataResponse {
             header_response: protocol::HeaderResponse { correlation_id: 1 },
             brokers: vec![
-                response::Broker {
+                Broker {
                     node_id: 1,
                     host: Bytes::from("localhost"),
                     port: 9092,
+                    rack: None,
                 },
-                response::Broker {
+                Broker {
                     node_id: 2,
                     host: Bytes::from("localhost"),
                     port: 9093,
+                    rack: None,
                 },
             ],
-            topics: vec![response::Topic {
+            controller_id: 1,
+            topics: vec![Topic {
                 error_code: KafkaCode::None,
-                name: Bytes::from("purchases"),
+                name: Bytes::from("benchmark"),
+                is_internal: false,
                 partitions: vec![
-                    response::Partition {
+                    Partition {
                         error_code: KafkaCode::None,
                         partition_index: 0,
                         leader_id: 2,
                         replica_nodes: vec![2],
                         isr_nodes: vec![2],
                     },
-                    response::Partition {
+                    Partition {
                         error_code: KafkaCode::None,
                         partition_index: 1,
-                        leader_id: 1,
-                        replica_nodes: vec![1],
-                        isr_nodes: vec![1],
-                    },
-                    response::Partition {
-                        error_code: KafkaCode::None,
-                        partition_index: 2,
                         leader_id: 2,
                         replica_nodes: vec![2],
                         isr_nodes: vec![2],
                     },
-                    response::Partition {
+                    Partition {
                         error_code: KafkaCode::None,
-                        partition_index: 3,
+                        partition_index: 2,
                         leader_id: 1,
                         replica_nodes: vec![1],
                         isr_nodes: vec![1],

--- a/src/protocol/metadata/request.rs
+++ b/src/protocol/metadata/request.rs
@@ -8,8 +8,8 @@
 //!
 //! ### Protocol Def
 //! ```text
-//! Metadata Request (Version: 1) => [topics] 
-//!   topics => name 
+//! Metadata Request (Version: 1) => [topics]
+//!   topics => name
 //!     name => STRING
 //! ```
 //!

--- a/src/protocol/metadata/request.rs
+++ b/src/protocol/metadata/request.rs
@@ -8,9 +8,9 @@
 //!
 //! ### Protocol Def
 //! ```text
-//! Metadata Request (Version: 0) => [topics]
-//!   topics => name
-//!   name => STRING
+//! Metadata Request (Version: 1) => [topics] 
+//!   topics => name 
+//!     name => STRING
 //! ```
 //!
 //! Note we are using version 0 of the request.
@@ -24,7 +24,7 @@ use crate::{
 };
 
 const API_KEY_METADATA: i16 = 3;
-const API_VERSION: i16 = 0;
+const API_VERSION: i16 = 1;
 
 /// The base Metadata request object.
 ///

--- a/tests/create_delete_topic.rs
+++ b/tests/create_delete_topic.rs
@@ -1,6 +1,6 @@
 mod testsupport;
 
-use samsa::prelude::{self, protocol, BrokerConnection, Error, KafkaCode, TcpConnection};
+use samsa::prelude::{self, protocol, BrokerConnection, ClusterMetadata, Error, KafkaCode, TcpConnection};
 use std::collections::HashMap;
 
 const CLIENT_ID: &str = "create delete topic integration test";
@@ -12,8 +12,9 @@ async fn it_can_create_and_delete_topics() -> Result<(), Box<Error>> {
     if skip {
         return Ok(());
     }
-    let mut conn = TcpConnection::new(brokers).await?;
+    let mut metadata = ClusterMetadata::<TcpConnection>::new(brokers, "rust".to_string(), vec![]).await?;
 
+    let conn: &mut TcpConnection = metadata.broker_connections.get_mut(&metadata.controller_id).unwrap();
     //
     // Create topic
     //

--- a/tests/create_delete_topic.rs
+++ b/tests/create_delete_topic.rs
@@ -1,6 +1,8 @@
 mod testsupport;
 
-use samsa::prelude::{self, protocol, BrokerConnection, ClusterMetadata, Error, KafkaCode, TcpConnection};
+use samsa::prelude::{
+    self, protocol, BrokerConnection, ClusterMetadata, Error, KafkaCode, TcpConnection,
+};
 use std::collections::HashMap;
 
 const CLIENT_ID: &str = "create delete topic integration test";
@@ -12,9 +14,13 @@ async fn it_can_create_and_delete_topics() -> Result<(), Box<Error>> {
     if skip {
         return Ok(());
     }
-    let mut metadata = ClusterMetadata::<TcpConnection>::new(brokers, "rust".to_string(), vec![]).await?;
+    let mut metadata =
+        ClusterMetadata::<TcpConnection>::new(brokers, "rust".to_string(), vec![]).await?;
 
-    let conn: &mut TcpConnection = metadata.broker_connections.get_mut(&metadata.controller_id).unwrap();
+    let conn: &mut TcpConnection = metadata
+        .broker_connections
+        .get_mut(&metadata.controller_id)
+        .unwrap();
     //
     // Create topic
     //


### PR DESCRIPTION
Our integration test for create & delete topic was not working because we were not being sure to send to the leader of the cluster, so it would fail intermittently

This PR:
- updated the metadata protocol version to get the leader id
- added to the cluster metadata struct to expose leader id
- updated integration test to use the correct connection to leader

How to run:
`KAFKA_BROKERS=localhost:9092 KAFKA_TOPIC=tester cargo test --tests --all-features -- --show-output --test-threads=1`