### PR TITLE
Bugfix: Read and write all bytes of a message

### DIFF
--- a/src/network/tcp.rs
+++ b/src/network/tcp.rs
@@ -89,7 +89,7 @@ impl TcpConnection {
                 .readable()
                 .await
                 .map_err(|e| Error::IoError(e.kind()))?;
-            
+
             // Try to read data, this may still fail with `WouldBlock`
             // if the readiness event is a false positive.
             match self.stream.try_read(&mut buf[index..]) {

--- a/src/network/tcp.rs
+++ b/src/network/tcp.rs
@@ -130,7 +130,7 @@ impl TcpConnection {
             match self.stream.try_write(&buf[index..]) {
                 Ok(n) => {
                     index += n;
-                    tracing::trace!("Write {} bytes", n);
+                    tracing::trace!("Wrote {} bytes", n);
                     if index != size {
                         tracing::trace!("Going back to write more, {} bytes left", size - index);
                     } else {

--- a/src/network/tcp.rs
+++ b/src/network/tcp.rs
@@ -81,21 +81,26 @@ impl TcpConnection {
 
     #[instrument(name = "network-read", level = "trace")]
     async fn read(&mut self, size: usize) -> Result<BytesMut> {
+        let mut buf = BytesMut::zeroed(size);
+        let mut index = 0_usize;
         loop {
             // Wait for the socket to be readable
             self.stream
                 .readable()
                 .await
                 .map_err(|e| Error::IoError(e.kind()))?;
-
-            let mut buf = BytesMut::zeroed(size);
-
+            
             // Try to read data, this may still fail with `WouldBlock`
             // if the readiness event is a false positive.
-            match self.stream.try_read(&mut buf) {
+            match self.stream.try_read(&mut buf[index..]) {
                 Ok(n) => {
+                    index += n;
                     tracing::trace!("Read {} bytes", n);
-                    return Ok(buf);
+                    if index != size {
+                        tracing::trace!("Going back to read more, {} bytes left", size - index);
+                    } else {
+                        return Ok(buf);
+                    }
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                     tracing::trace!("WouldBlock on read");
@@ -111,6 +116,8 @@ impl TcpConnection {
 
     #[instrument(name = "network-write", level = "trace")]
     async fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        let size = buf.len();
+        let mut index = 0_usize;
         loop {
             // Wait for the socket to be writable
             self.stream
@@ -120,13 +127,18 @@ impl TcpConnection {
 
             // Try to write data, this may still fail with `WouldBlock`
             // if the readiness event is a false positive.
-            match self.stream.try_write(buf) {
+            match self.stream.try_write(&buf[index..]) {
                 Ok(n) => {
-                    tracing::trace!("Wrote {} bytes", n);
-                    return Ok(n);
+                    index += n;
+                    tracing::trace!("Write {} bytes", n);
+                    if index != size {
+                        tracing::trace!("Going back to write more, {} bytes left", size - index);
+                    } else {
+                        return Ok(n);
+                    }
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                    tracing::trace!("WouldBlock on read");
+                    tracing::trace!("WouldBlock on write");
                     continue;
                 }
                 Err(e) => {


### PR DESCRIPTION
The TCP network code was not reading the entire buffer length nor writing the entire buffer to the cluster.

This would cause some strange behavior when trying to read and write large messages (> than a packet size)


Note: This is not an issue for TLS because they provide methods that read_exact and write_all (so they did not make the same mistake as us)