### PR TITLE
feat: Create dedicated constructor method for tcp producer/consumer

### DIFF
--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), ()> {
     // Test fetch (read)
     //
     tracing::info!("Connecting to cluster");
-    let stream = ConsumerBuilder::<TcpConnection>::new(
+    let stream = ConsumerBuilder::new_tcp(
         bootstrap_addrs.clone(),
         TopicPartitionsBuilder::new()
             .assign(topic.to_string(), vec![0])

--- a/src/consumer_builder.rs
+++ b/src/consumer_builder.rs
@@ -1,5 +1,6 @@
 use crate::consumer::{Consumer, FetchParams, PartitionOffsets, TopicPartitions};
 use crate::metadata::ClusterMetadata;
+use crate::prelude::TcpConnection;
 use crate::{
     error::{Error, KafkaCode, Result},
     metadata::{self},
@@ -47,6 +48,18 @@ pub struct ConsumerBuilder<T: BrokerConnection> {
     pub(crate) assigned_topic_partitions: TopicPartitions,
     /// Offsets to read from for each assigned topic partition.
     pub(crate) offsets: PartitionOffsets,
+}
+
+impl<T> ConsumerBuilder<T: BrokerConnection> {
+    /// Start a consumer builder using a tcp connection.
+    ///
+    /// Equivalent to `ConsumerBuilder::<TcpConnection>::new(...)`. To complete, use the [`build`](Self::build) method.
+    pub async fn new_tcp(
+        connection_params: TcpConnection::ConnConfig,
+        assigned_topic_partitions: TopicPartitions,
+    ) -> Result<ConsumerBuilder<TcpConnection>> {
+        ConsumerBuilder::<TcpConnection>::new(connection_params, assigned_topic_partitions).await
+    }
 }
 
 impl<'a, T: BrokerConnection + Clone + Debug> ConsumerBuilder<T> {

--- a/src/producer_builder.rs
+++ b/src/producer_builder.rs
@@ -5,7 +5,7 @@ use tokio::sync::mpsc::{channel, unbounded_channel, Receiver, UnboundedSender};
 use tokio_stream::{Stream, StreamExt};
 
 use crate::network::BrokerConnection;
-use crate::prelude::Compression;
+use crate::prelude::{Compression, TcpConnection};
 use crate::producer::{flush_producer, ProduceMessage, ProduceParams, Producer};
 use crate::protocol::produce::request::Attributes;
 use crate::protocol::ProduceResponse;
@@ -56,6 +56,16 @@ impl<'a, T> ProducerBuilder<T>
 where
     T: BrokerConnection + Clone + Debug + Send + Sync + 'static,
 {
+    /// Start a producer builder using a tcp connection.
+    ///
+    /// Equivalent to `ProducerBuilder::<TcpConnection>::new(...)`. To complete, use the [`build`](Self::build) method.
+    pub async fn new_tcp(
+        connection_params: TcpConnection::ConnConfig,
+        topics: Vec<String>,
+    ) -> Result<ProducerBuilder<TcpConnection>> {
+        ProducerBuilder::<TcpConnection>::new(connection_params, topics).await
+    }
+
     /// Start a producer builder. To complete, use the [`build`](Self::build) method.
     pub async fn new(connection_params: T::ConnConfig, topics: Vec<String>) -> Result<Self> {
         let cluster_metadata = ClusterMetadata::new(


### PR DESCRIPTION
Adds methods for directly creating `ProducerBuilder<TcpConnection>` and `ConsumerBuilder<TcpConnection>` without needing to define the generic `T: ConnConfig`.