### PR TITLE
set the client id on the fetch params and on self

### DIFF
--- a/examples/consumer_group.rs
+++ b/examples/consumer_group.rs
@@ -40,8 +40,16 @@ async fn main() -> Result<(), ()> {
     tokio::pin!(stream);
 
     while let Some(message) = stream.next().await {
-        let messages: Vec<ConsumeMessage> = message.unwrap().collect();
-        tracing::info!("{:?}", messages);
+        match message {
+            Ok(msg) => {
+                let messages: Vec<ConsumeMessage> = msg.collect();
+                tracing::info!("{:?}", messages);
+            }
+            Err(e) => {
+                tracing::error!("Failed to process message: {:?}", e);
+            }
+        }
     }
+
     Ok(())
 }

--- a/examples/consumer_group_without_builder.rs
+++ b/examples/consumer_group_without_builder.rs
@@ -1,0 +1,56 @@
+use std::time::Duration;
+use tokio_stream::StreamExt;
+use tracing::{error, info};
+use samsa::prelude::{BrokerAddress, ConsumerGroupBuilder, TcpConnection, TopicPartitionsBuilder};
+
+async fn start_consumer() {
+    let bootstrap_address = vec![BrokerAddress {
+        host: "localhost".to_owned(),
+        port: 9092
+    }];
+
+    let partitions = vec![0];
+    let topic_name = "user-notification-events".to_string();
+    let assignment = TopicPartitionsBuilder::new()
+        .assign(topic_name, partitions)
+        .build();
+
+    let consumer = ConsumerGroupBuilder::<TcpConnection>::new(
+        bootstrap_address,
+        "ism".to_string(),
+        assignment,
+    ).await
+        .expect("Could not create consumer.")
+        .client_id("ism-1".parse().unwrap()) //SETTING MY CLIENT ID
+
+        .build()
+        .await
+        .expect("Could not create consumer.");
+
+    let stream = consumer.into_stream().throttle(Duration::from_secs(5));
+    // have to pin streams before iterating
+    tokio::pin!(stream);
+
+    // Stream will do nothing unless consumed.
+    while let Some(msg) = stream.next().await {
+        match msg {
+            Ok(msg) => {
+                msg.for_each(|notification| {
+                    match String::from_utf8(notification.value.to_vec()) {
+                        Ok(str) => info!("{}", str),
+                        Err(err) => error!("{}", err),
+                    }
+                    info!("Received message: {}", notification.offset);
+                });
+            },
+            Err(e) => {
+                error!("Error: {e}");
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    start_consumer().await
+}

--- a/src/consumer_group_builder.rs
+++ b/src/consumer_group_builder.rs
@@ -53,7 +53,8 @@ impl<T: BrokerConnection> ConsumerGroupBuilder<T> {
     }
 
     pub fn client_id(mut self, client_id: String) -> Self {
-        self.fetch_params.client_id = client_id;
+        self.client_id = client_id;
+        self.fetch_params.client_id = self.client_id.clone();
         self
     }
 


### PR DESCRIPTION
Client ID was only being set on the FetchParams but not on the original struct.  
This breaks the expectations of the client as consumer builder should correctly mutate the client id when told to do so